### PR TITLE
Support for stochastic models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,3 +31,5 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Language: en-GB
+Remotes:
+    mrc-ide/dust

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ LinkingTo:
     cpp11
 Suggests:
     cpp11,
-    decor,    
+    decor,
+    dust,
     mvtnorm,
     numDeriv,
     pkgload,

--- a/R/model.R
+++ b/R/model.R
@@ -252,7 +252,7 @@ validate_model_rng_state <- function(model, properties, call) {
     return(NULL)
   }
   if (!is.function(model$set_rng_state)) {
-    if (isTRUE(model$is_stochastic)) {
+    if (isTRUE(properties$is_stochastic)) {
       hint <- paste("You have specified 'is_stochastic = TRUE', so in order",
                     "to use your stochastic model we need a way of setting",
                     "its state")

--- a/R/model.R
+++ b/R/model.R
@@ -25,7 +25,8 @@ mcstate_model_properties <- function(has_gradient = NULL,
                                      has_direct_sample = NULL,
                                      is_stochastic = NULL) {
   ret <- list(has_gradient = has_gradient,
-              has_direct_sample = has_direct_sample)
+              has_direct_sample = has_direct_sample,
+              is_stochastic = is_stochastic)
   class(ret) <- "mcstate_model_properties"
   ret
 }
@@ -247,12 +248,23 @@ validate_model_rng_state <- function(model, properties, call) {
   if (isFALSE(properties$is_stochastic)) {
     return(NULL)
   }
+  if (is.null(properties$is_stochastic) && is.null(model$set_rng_state)) {
+    return(NULL)
+  }
   if (!is.function(model$set_rng_state)) {
+    if (isTRUE(model$is_stochastic)) {
+      hint <- paste("You have specified 'is_stochastic = TRUE', so in order",
+                    "to use your stochastic model we need a way of setting",
+                    "its state")
+    } else {
+      hint <- paste("I found a non-function element 'set_rng_state' within",
+                    "your model and you have not set the 'is_stochastic'",
+                    "property")
+    }
     cli::cli_abort(
       c("Expected 'model$set_rng_state' to be a function",
-        i = paste("You have specified 'is_stochastic = TRUE', so in order",
-                  "to use your stochastic model we need a way of setting",
-                  "its state")))
+        i = hint),
+      arg = "model", call = call)
   }
   list(set = model$set_rng_state)
 }

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -1,5 +1,7 @@
 ##' Create a simple random walk sampler, which uses a symmetric
-##' proposal to move around parameter space.
+##' proposal to move around parameter space.  This sampler supports
+##' sampling from models where the likelihood is only computable
+##' randomly (e.g., for pmcmc).
 ##'
 ##' @title Random Walk Sampler
 ##'
@@ -37,6 +39,9 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
         cli::cli_abort(
           "Incompatible length parameters ({n_pars}) and vcv ({n_vcv})")
       }
+    }
+    if (isTRUE(model$properties$is_stochastic)) {
+      model$model$set_rng_state(rng)
     }
   }
 

--- a/man/mcstate_model.Rd
+++ b/man/mcstate_model.Rd
@@ -83,21 +83,19 @@ contrast to the \code{rng} that is passed through to \code{direct_sample}
 as that is the \emph{sampler's} rng stream, but we assume models will
 look after their own stream, and that they may need many
 streams).  Models that provide this method are assumed to be
-stochastic; however, you can use the \code{is_stochastic} argument to
-override this (e.g., to run a stochastic model with its
-deterministic expectation).  This function takes an
-\link{mcstate_rng} object and uses it to seed the random number state
-for your model.  You have two options here (1) hold a copy of
-the provided object and draw samples from it as needed (in
-effect sharing the random number stream with the sampler) or
-create a new rng stream from a jump with this stream (we'll
-provide a utility for doing this but at present doing
-\code{mcstate_rng$new(rng$state(), n_streams)$jump()$state()} will
-do).  The main reason you'd do that is if you need multiple
-(perhaps parallel) streams of random numbers in your model.  The
-\verb{$jump()} is very important, otherwise you'll end up correlated
-with the draws from the sampler.
-\item \code{get_rng_state}: A function to fetch the rng state from the
-model.  This wil be used to make restartable chains.
+stochastic; however, you can use the \code{is_stochastic} property
+(via \code{\link[=mcstate_model_properties]{mcstate_model_properties()}}) to override this (e.g., to
+run a stochastic model with its deterministic expectation).
+This function takes an \link{mcstate_rng} object and uses it to seed
+the random number state for your model.  You have two options
+here (1) hold a copy of the provided object and draw samples
+from it as needed (in effect sharing the random number stream
+with the sampler) or create a new rng stream from a jump with
+this stream (we'll provide a utility for doing this but at
+present doing \code{mcstate_rng$new(rng$state(), n_streams)$jump()$state()} will do).  The main reason you'd do
+that is if you need multiple (perhaps parallel) streams of
+random numbers in your model.  The \verb{$jump()} is very important,
+otherwise you'll end up correlated with the draws from the
+sampler.
 }
 }

--- a/man/mcstate_model.Rd
+++ b/man/mcstate_model.Rd
@@ -26,6 +26,7 @@ see \code{\link[=mcstate_model_properties]{mcstate_model_properties()}}.  Curren
 \itemize{
 \item \code{has_gradient}: the model can compute its gradient
 \item \code{has_direct_sample}: the model can sample from parameters space
+\item \code{is_stochastic}: the model will behave stochastically
 }
 }
 }
@@ -77,5 +78,26 @@ calculated after a density calculation, or density after
 gradient, where these are called with the same parameters.  This
 function is optional (and may not be well defined or possible to
 define).
+\item \code{set_rng_state}: A function to set the state (this is in
+contrast to the \code{rng} that is passed through to \code{direct_sample}
+as that is the \emph{sampler's} rng stream, but we assume models will
+look after their own stream, and that they may need many
+streams).  Models that provide this method are assumed to be
+stochastic; however, you can use the \code{is_stochastic} argument to
+override this (e.g., to run a stochastic model with its
+deterministic expectation).  This function takes an
+\link{mcstate_rng} object and uses it to seed the random number state
+for your model.  You have two options here (1) hold a copy of
+the provided object and draw samples from it as needed (in
+effect sharing the random number stream with the sampler) or
+create a new rng stream from a jump with this stream (we'll
+provide a utility for doing this but at present doing
+\code{mcstate_rng$new(rng$state(), n_streams)$jump()$state()} will
+do).  The main reason you'd do that is if you need multiple
+(perhaps parallel) streams of random numbers in your model.  The
+\verb{$jump()} is very important, otherwise you'll end up correlated
+with the draws from the sampler.
+\item \code{get_rng_state}: A function to fetch the rng state from the
+model.  This wil be used to make restartable chains.
 }
 }

--- a/man/mcstate_model_properties.Rd
+++ b/man/mcstate_model_properties.Rd
@@ -4,7 +4,11 @@
 \alias{mcstate_model_properties}
 \title{Describe model properties}
 \usage{
-mcstate_model_properties(has_gradient = NULL, has_direct_sample = NULL)
+mcstate_model_properties(
+  has_gradient = NULL,
+  has_direct_sample = NULL,
+  is_stochastic = NULL
+)
 }
 \arguments{
 \item{has_gradient}{Logical, indicating if the model has a
@@ -14,6 +18,10 @@ the model.}
 \item{has_direct_sample}{Logical, indicating if the model has a
 \code{direct_sample} method.  Use \code{NULL} (the default) to detect this
 from the model.}
+
+\item{is_stochastic}{Logical, indicating if the model is
+stochastic.  Stochastic models must supply a \code{set_rng_state}
+method and we might support a \code{get_rng_state} method later.}
 }
 \value{
 A list of class \code{mcstate_model_properties} which should

--- a/man/mcstate_sampler_random_walk.Rd
+++ b/man/mcstate_sampler_random_walk.Rd
@@ -23,5 +23,7 @@ A \code{mcstate_sampler} object, which can be used with
 }
 \description{
 Create a simple random walk sampler, which uses a symmetric
-proposal to move around parameter space.
+proposal to move around parameter space.  This sampler supports
+sampling from models where the likelihood is only computable
+randomly (e.g., for pmcmc).
 }

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -13,3 +13,65 @@ ex_simple_gamma1 <- function(shape = 1, rate = 1) {
       gradient = function(x) (shape - 1) / x - rate,
       domain = rbind(c(0, Inf)))))
 }
+
+
+ex_dust_sir <- function(n_particles = 100, n_threads = 1,
+                        deterministic = FALSE) {
+  testthat::skip_if_not_installed("dust")
+  sir <- dust::dust_example("sir")
+
+  np <- 10
+  end <- 150 * 4
+  times <- seq(0, end, by = 4)
+  ans <- sir$new(list(), 0, np, seed = 1L)$simulate(times)
+  dat <- data.frame(time = times[-1], incidence = ans[5, 1, -1])
+
+  ## TODO: an upshot here is that our dust models are always going to
+  ## need to be initialisable; we might need to sample from the
+  ## statistical parameters, or set things up to allow two-phases of
+  ## initialsation (which is I think where we are heading, so that's
+  ## fine).
+  model <- sir$new(list(), 0, n_particles, seed = 1L, n_threads = n_threads,
+                   deterministic = deterministic)
+  model$set_data(dust::dust_data(dat))
+
+  prior_beta_shape <- 1
+  prior_beta_rate <- 1 / 0.5
+  prior_gamma_shape <- 1
+  prior_gamma_rate <- 1 / 0.5
+
+  density <- function(x) {
+    beta <- x[[1]]
+    gamma <- x[[2]]
+    prior <- dgamma(beta, prior_beta_shape, prior_beta_rate, log = TRUE) +
+      dgamma(gamma, prior_gamma_shape, prior_gamma_rate, log = TRUE)
+    if (is.finite(prior)) {
+      model$update_state(
+        pars = list(beta = x[[1]], gamma = x[[2]]),
+        time = 0,
+        set_initial_state = TRUE)
+      ll <- model$filter()$log_likelihood
+    } else {
+      ll <- -Inf
+    }
+    ll + prior
+  }
+
+  direct_sample <- function(rng) {
+    c(rng$gamma(1, prior_beta_shape, 1 / prior_beta_rate),
+      rng$gamma(1, prior_gamma_shape, 1 / prior_gamma_rate))
+  }
+
+  set_rng_state <- function(rng) {
+    state <- mcstate_rng$new(rng$state(), n_particles + 1)$jump()$state()
+    model$set_rng_state(state)
+  }
+
+  mcstate_model(
+    list(density = density,
+         direct_sample = direct_sample,
+         parameters = c("beta", "gamma"),
+         domain = cbind(c(0, 0), c(Inf, Inf)),
+         set_rng_state = set_rng_state),
+    is_stochastic = !deterministic)
+}

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -73,5 +73,5 @@ ex_dust_sir <- function(n_particles = 100, n_threads = 1,
          parameters = c("beta", "gamma"),
          domain = cbind(c(0, 0), c(Inf, Inf)),
          set_rng_state = set_rng_state),
-    is_stochastic = !deterministic)
+    mcstate_model_properties(is_stochastic = !deterministic))
 }

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -119,3 +119,13 @@ test_that("require properties are correct type", {
       list(has_gradient = FALSE)),
     "Expected 'properties' to be a 'mcstate_model_properties' object")
 })
+
+
+test_that("stochastic models need an rng setting function", {
+  expect_error(
+    mcstate_model(list(density = identity),
+                  parameters = "a",
+                  is_stochastic = TRUE),
+    "Expected 'model$set_rng_state' to be a function",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -4,7 +4,8 @@ test_that("can create a minimal model", {
   expect_s3_class(m, "mcstate_model")
   expect_equal(m$properties,
                mcstate_model_properties(has_gradient = FALSE,
-                                        has_direct_sample = FALSE))
+                                        has_direct_sample = FALSE,
+                                        is_stochastic = FALSE))
   expect_equal(m$domain, cbind(-Inf, Inf))
   expect_equal(m$parameters, "a")
   expect_equal(m$density(0), dnorm(0, log = TRUE))
@@ -15,7 +16,8 @@ test_that("can create a more interesting model", {
   m <- ex_simple_gamma1()
   expect_equal(m$properties,
                mcstate_model_properties(has_gradient = TRUE,
-                                        has_direct_sample = TRUE))
+                                        has_direct_sample = TRUE,
+                                        is_stochastic = FALSE))
   expect_equal(m$domain, cbind(0, Inf))
   expect_equal(m$parameters, "gamma")
   expect_equal(m$density(1), dgamma(1, 1, 1, log = TRUE))

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -128,4 +128,9 @@ test_that("stochastic models need an rng setting function", {
       mcstate_model_properties(is_stochastic = TRUE)),
     "Expected 'model$set_rng_state' to be a function",
     fixed = TRUE)
+  expect_error(
+    mcstate_model(
+      list(density = identity, parameters = "a", set_rng_state = TRUE)),
+    "Expected 'model$set_rng_state' to be a function",
+    fixed = TRUE)
 })

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -123,9 +123,9 @@ test_that("require properties are correct type", {
 
 test_that("stochastic models need an rng setting function", {
   expect_error(
-    mcstate_model(list(density = identity),
-                  parameters = "a",
-                  is_stochastic = TRUE),
+    mcstate_model(
+      list(density = identity, parameters = "a"),
+      mcstate_model_properties(is_stochastic = TRUE)),
     "Expected 'model$set_rng_state' to be a function",
     fixed = TRUE)
 })

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -133,4 +133,15 @@ test_that("stochastic models need an rng setting function", {
       list(density = identity, parameters = "a", set_rng_state = TRUE)),
     "Expected 'model$set_rng_state' to be a function",
     fixed = TRUE)
+  expect_error(
+    mcstate_model(
+      list(density = identity, parameters = "a", set_rng_state = TRUE),
+      mcstate_model_properties(is_stochastic = TRUE)),
+    "Expected 'model$set_rng_state' to be a function",
+    fixed = TRUE)
+  expect_no_error(
+    res <- mcstate_model(
+      list(density = identity, parameters = "a", set_rng_state = TRUE),
+      mcstate_model_properties(is_stochastic = FALSE)))
+  expect_null(res$set_rng_state)
 })

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -38,7 +38,7 @@ test_that("can draw samples from a random model", {
   vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
   sampler <- mcstate_sampler_random_walk(vcv = vcv)
   res <- mcstate_sample(m, sampler, 20)
-  expect_setequal(names(res), c("pars", "density", "details"))
+  expect_setequal(names(res), c("pars", "density", "details", "chain"))
   ## OK, this is ready then to start thinking about how we inject
   ## observer support in here; we'll need access to the actual model
   ## in order to get trajectories out etc, but that's not super

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -39,9 +39,4 @@ test_that("can draw samples from a random model", {
   sampler <- mcstate_sampler_random_walk(vcv = vcv)
   res <- mcstate_sample(m, sampler, 20)
   expect_setequal(names(res), c("pars", "density", "details", "chain"))
-  ## OK, this is ready then to start thinking about how we inject
-  ## observer support in here; we'll need access to the actual model
-  ## in order to get trajectories out etc, but that's not super
-  ## obvious really; that means we're going to need some sort of
-  ## special sauce for the observer function really.
 })

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -30,3 +30,18 @@ test_that("validate sampler against model on initialisation", {
     "Incompatible length parameters (1) and vcv (2)",
     fixed = TRUE)
 })
+
+
+test_that("can draw samples from a random model", {
+  set.seed(1)
+  m <- ex_dust_sir()
+  vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
+  sampler <- mcstate_sampler_random_walk(vcv = vcv)
+  res <- mcstate_sample(m, sampler, 20)
+  expect_setequal(names(res), c("pars", "density", "details"))
+  ## OK, this is ready then to start thinking about how we inject
+  ## observer support in here; we'll need access to the actual model
+  ## in order to get trajectories out etc, but that's not super
+  ## obvious really; that means we're going to need some sort of
+  ## special sauce for the observer function really.
+})


### PR DESCRIPTION
Note that this PR pulls in `dust` for now, to use in the tests.  That is probably not what we really want because dust is going to depend on mcstate for its rng calls!  Once we work out what we need, I'll hand-write a version of this model that does the job, but this setup should be ok for a while (probably until we know enough to write dust2, really).

I've left a little placeholder in around *getting* rng state from the model; that is going to interact with restartable mcmc in ways that are going to require some care I think.

There's no actual testing in the stochastic model + random walk; however, this constitutes "particle MCMC" which is cool.  There are a couple of small features we will likely add there later based the covid work:

* the ability to rerun the likelihood every so often separate from the proposal, avoiding getting stochastically stuck (I'll properly work through this with Marc and Ed)
* the ability to indicate the minimum likelihood that we'd accept (this turns out to be useful for getting an early exit in the particle filter)

