### PR TITLE
Don't include initial point in chain

### DIFF
--- a/R/runner.R
+++ b/R/runner.R
@@ -100,15 +100,13 @@ mcstate_run_chain <- function(pars, model, sampler, n_steps, rng) {
   state <- list(pars = pars, density = density)
   sampler$initialise(state, model, rng)
 
-  history_pars <- matrix(NA_real_, n_steps + 1, length(pars))
-  history_pars[1, ] <- pars
-  history_density <- rep(NA_real_, n_steps + 1)
-  history_density[[1]] <- density
+  history_pars <- matrix(NA_real_, n_steps, length(pars))
+  history_density <- rep(NA_real_, n_steps)
 
   for (i in seq_len(n_steps)) {
     state <- sampler$step(state, model, rng)
-    history_pars[i + 1, ] <- state$pars
-    history_density[[i + 1]] <- state$density
+    history_pars[i, ] <- state$pars
+    history_density[[i]] <- state$density
   }
 
   ## Pop the parameter names on last
@@ -124,7 +122,8 @@ mcstate_run_chain <- function(pars, model, sampler, n_steps, rng) {
   internal <- list(used_r_rng = !identical(get_r_rng_state(), r_rng_state),
                    rng_state = rng$state())
 
-  list(pars = history_pars,
+  list(initial = pars,
+       pars = history_pars,
        density = history_density,
        details = details,
        internal = internal)

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -145,7 +145,7 @@ hmc_transform <- function(domain) {
   }
 
   ## Save finite bounds for later:
-  a <- lower[is_bounded | is_semi_infinite]
+  a <- lower[is_bounded]
   b <- upper[is_bounded]
 
   list(

--- a/man/mcstate_sample.Rd
+++ b/man/mcstate_sample.Rd
@@ -44,7 +44,22 @@ restartable.  This will add additional data to the chains
 object.}
 }
 \value{
-A list of parameters and densities.
+A list of parameters and densities; we'll write tools for
+dealing with this later.  Elements include:
+\itemize{
+\item \code{pars}: A matrix with as many columns as you have parameters, and
+as many rows as the total number of samples taken across all
+chains (\code{n_steps * n_chains})
+\item \code{density}: A vector of model log densities, one per step (length
+\code{n_steps * n_chains})
+\item \code{initial}: A record of the initial conditions, a matrix with as
+many columns as you have parameters and \code{n_chains} rows
+\item \code{details}: Additional details reported by the sampler; this will
+be a list of length \code{n_chains} (or \code{NULL}) and the details
+depend on the sampler.  This one is subject to change.
+\item \code{chain}: An integer vector indicating the chain that the samples
+came from (1, 2, ..., \code{n_chains})
+}
 }
 \description{
 Sample from a model.  Uses a Monte Carlo method (or possibly

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -17,13 +17,14 @@ test_that("sampler return value contains history", {
   model <- ex_simple_gamma1()
   sampler <- mcstate_sampler_random_walk(vcv = diag(1) * 0.01)
   res <- mcstate_sample(model, sampler, 100, 1)
-  expect_setequal(names(res), c("pars", "density", "details", "chain"))
+  expect_setequal(names(res),
+                  c("pars", "density", "initial", "details", "chain"))
   expect_true(is.matrix(res$pars))
-  expect_equal(dim(res$pars), c(101, 1))
+  expect_equal(dim(res$pars), c(100, 1))
   expect_equal(dimnames(res$pars), list(NULL, "gamma"))
-  expect_length(res$density, 101)
+  expect_length(res$density, 100)
   expect_equal(res$density, apply(res$pars, 1, model$density))
-  expect_equal(unname(res$pars[1, ]), 1)
+  expect_equal(res$initial, cbind(gamma = 1))
   expect_null(res$details)
 })
 

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -35,15 +35,13 @@ test_that("can output debug traces", {
   expect_null(res1$details)
   expect_length(res2$details, 1)
   expect_equal(names(res2$details[[1]]), "debug")
-  ## Marc: is this expected given things _should_ be fairly well
-  ## behaved on this surface?
   expect_equal(res2$details[[1]]$debug$accept, rep(TRUE, 30))
 
   pars <- res2$details[[1]]$debug$pars
   expect_equal(dim(pars), c(11, 2, 30))
   expect_equal(dimnames(pars), list(NULL, c("a", "b"), NULL))
-  expect_equal(t(pars[1, , ]), res2$pars[-31, ])
-  expect_equal(t(pars[11, , ]), res2$pars[-1, ])
+  expect_equal(t(pars[1, , ]), rbind(res2$initial, res2$pars[-30, ]))
+  expect_equal(t(pars[11, , ]), res2$pars)
 })
 
 

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -2,8 +2,8 @@ test_that("can draw samples from a trivial model", {
   m <- ex_simple_gamma1()
   sampler <- mcstate_sampler_random_walk(vcv = matrix(0.01, 1, 1))
   res <- mcstate_sample(m, sampler, 100)
-  expect_equal(names(res), c("pars", "density", "details", "chain"))
-  expect_equal(res$chain, rep(1, 101))
+  expect_equal(names(res), c("pars", "density", "initial", "details", "chain"))
+  expect_equal(res$chain, rep(1, 100))
 })
 
 
@@ -38,5 +38,6 @@ test_that("can draw samples from a random model", {
   vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
   sampler <- mcstate_sampler_random_walk(vcv = vcv)
   res <- mcstate_sample(m, sampler, 20)
-  expect_setequal(names(res), c("pars", "density", "details", "chain"))
+  expect_setequal(names(res),
+                  c("pars", "density", "initial", "details", "chain"))
 })


### PR DESCRIPTION
This PR drops the initial point from the chain.  It complicates a few things (in implementing support for observers most recently) to retain it so I've dropped it.  Ed indicated that it was useful to know where we've come from so I have retained an `initial` field which holds initial conditions