### PR TITLE
Improvements to sampler initialisation and restart

### DIFF
--- a/R/runner.R
+++ b/R/runner.R
@@ -9,11 +9,12 @@
 ##'
 ##' @export
 mcstate_runner_serial <- function() {
-  run <- function(pars, model, sampler, n_steps, rng) {
+  run <- function(pars, model, sampler, n_steps, rng, sampler_state) {
     lapply(
       seq_along(rng),
       function(i) {
-        mcstate_run_chain(pars[i, ], model, sampler, n_steps, rng[[i]])
+        mcstate_run_chain(pars[i, ], model, sampler, n_steps, rng[[i]],
+                          sampler_state[[i]])
       })
   }
   structure(list(run = run), class = "mcstate_runner")
@@ -58,7 +59,7 @@ mcstate_runner_parallel <- function(n_workers) {
   ## get the advantage that the cluster startup happens asyncronously
   ## and may be ready by the time we actually pass any work onto it.
 
-  run <- function(pars, model, sampler, n_steps, rng) {
+  run <- function(pars, model, sampler, n_steps, rng, sampler_state) {
     n_chains <- length(rng)
     cl <- parallel::makeCluster(min(n_chains, n_workers))
     on.exit(parallel::stopCluster(cl))
@@ -80,6 +81,7 @@ mcstate_runner_parallel <- function(n_workers) {
       mcstate_run_chain_parallel,
       pars = pars_list,
       rng = rng_state,
+      sampler_state = sampler_state,
       MoreArgs = list(model = model, sampler = sampler, n_steps = n_steps))
   }
   structure(list(run = run), class = "mcstate_runner")
@@ -88,16 +90,21 @@ mcstate_runner_parallel <- function(n_workers) {
 
 ## Later we could return the mutated rng state and set it back into
 ## the sampler, if we needed to continue for any reason.
-mcstate_run_chain_parallel <- function(pars, model, sampler, n_steps, rng) {
+mcstate_run_chain_parallel <- function(pars, model, sampler, n_steps, rng,
+                                       sampler_state) {
   rng <- mcstate_rng$new(rng)
-  mcstate_run_chain(pars, model, sampler, n_steps, rng)
+  mcstate_run_chain(pars, model, sampler, n_steps, rng, sampler_state)
 }
 
 
-mcstate_run_chain <- function(pars, model, sampler, n_steps, rng) {
+mcstate_run_chain <- function(pars, model, sampler, n_steps, rng,
+                              sampler_state) {
   r_rng_state <- get_r_rng_state()
   density <- model$density(pars)
   state <- sampler$initialise(pars, model, rng)
+  if (!is.null(sampler_state)) {
+    sampler$set_internal_state(sampler_state)
+  }
 
   if (!is.finite(state$density)) {
     ## Ideally, we'd do slightly better than this; it might be worth
@@ -139,7 +146,8 @@ mcstate_run_chain <- function(pars, model, sampler, n_steps, rng) {
   ## some particular way with no guarantees about the format).  We
   ## might hold things like start and stop times here in future.
   internal <- list(used_r_rng = !identical(get_r_rng_state(), r_rng_state),
-                   rng_state = rng$state())
+                   rng_state = rng$state(),
+                   sampler_state = sampler$get_internal_state())
 
   list(initial = pars,
        pars = history_pars,

--- a/R/runner.R
+++ b/R/runner.R
@@ -97,8 +97,7 @@ mcstate_run_chain_parallel <- function(pars, model, sampler, n_steps, rng) {
 mcstate_run_chain <- function(pars, model, sampler, n_steps, rng) {
   r_rng_state <- get_r_rng_state()
   density <- model$density(pars)
-  state <- list(pars = pars, density = density)
-  sampler$initialise(state, model, rng)
+  state <- sampler$initialise(pars, model, rng)
 
   if (!is.finite(state$density)) {
     ## Ideally, we'd do slightly better than this; it might be worth

--- a/R/sample.R
+++ b/R/sample.R
@@ -120,7 +120,7 @@ mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
   rng <- lapply(samples$restart$rng_state,
                 function(s) mcstate_rng$new(seed = s))
   model <- samples$restart$model
-  pars <- samples$restart$pars
+  pars <- unname(samples$restart$pars)
   sampler <- samples$restart$sampler
   sampler_state <- samples$restart$sampler_state
   runner <- samples$restart$runner

--- a/R/sample.R
+++ b/R/sample.R
@@ -76,8 +76,9 @@ mcstate_sample <- function(model, sampler, n_steps, initial = NULL,
   }
 
   rng <- initial_rng(n_chains)
+  sampler_state <- vector("list", n_chains)
   pars <- initial_parameters(initial, model, rng, environment())
-  res <- runner$run(pars, model, sampler, n_steps, rng)
+  res <- runner$run(pars, model, sampler, n_steps, rng, sampler_state)
 
   samples <- combine_chains(res)
   if (restartable) {
@@ -121,10 +122,11 @@ mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
   model <- samples$restart$model
   pars <- samples$restart$pars
   sampler <- samples$restart$sampler
+  sampler_state <- samples$restart$sampler_state
   runner <- samples$restart$runner
 
-  res <- runner$run(pars, model, sampler, n_steps, rng)
-  samples <- append_chains(samples, combine_chains(res))
+  res <- runner$run(pars, model, sampler, n_steps, rng, sampler_state)
+  samples <- append_chains(samples, combine_chains(res), sampler)
 
   if (restartable) {
     samples$restart <- restart_data(res, model, sampler, runner)
@@ -133,11 +135,14 @@ mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
 }
 
 
-mcstate_sampler <- function(name, initialise, step, finalise) {
+mcstate_sampler <- function(name, initialise, step, finalise,
+                            get_internal_state, set_internal_state) {
   ret <- list(name = name,
               initialise = initialise,
               step = step,
-              finalise = finalise)
+              finalise = finalise,
+              get_internal_state = get_internal_state,
+              set_internal_state = set_internal_state)
   class(ret) <- "mcstate_sampler"
   ret
 }
@@ -270,7 +275,7 @@ combine_chains <- function(res) {
 
 
 ## This is absolutely terrible, but it will get there.
-append_chains <- function(prev, curr) {
+append_chains <- function(prev, curr, sampler) {
   n_chains <- length(prev$restart$rng_state)
   i <- split(seq_along(prev$chain), prev$chain)
   j <- split(seq_along(curr$chain) + length(prev$chain), curr$chain)
@@ -278,13 +283,7 @@ append_chains <- function(prev, curr) {
 
   pars <- rbind(prev$pars, curr$pars)[k, , drop = FALSE]
   density <- c(prev$density, curr$density)[k]
-  if (!is.null(prev$details) || !is.null(curr$details)) {
-    ## This needs to wait until hmc or adaptive sampling are merged to
-    ## work with.
-    cli::cli_abort("Can't yet merge chains with details")
-  } else {
-    details <- NULL
-  }
+  details <- curr$details
   chain <- c(prev$chain, curr$chain)[k]
 
   samples <- list(pars = pars,
@@ -311,11 +310,14 @@ restart_data <- function(res, model, sampler, runner) {
   pars <- vapply(res, function(x) x$pars[nrow(x$pars), ], numeric(n_pars))
   if (n_pars == 1) {
     pars <- matrix(pars, ncol = 1)
+  } else {
+    pars <- t(pars)
   }
   list(rng_state = lapply(res, function(x) x$internal$rng_state),
        pars = pars,
        model = model,
        sampler = sampler,
+       sampler_state = lapply(res, function(x) x$internal$sampler_state),
        runner = runner)
 }
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -126,7 +126,7 @@ mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
   runner <- samples$restart$runner
 
   res <- runner$run(pars, model, sampler, n_steps, rng, sampler_state)
-  samples <- append_chains(samples, combine_chains(res), sampler)
+  samples <- append_chains(samples, combine_chains(res))
 
   if (restartable) {
     samples$restart <- restart_data(res, model, sampler, runner)
@@ -275,7 +275,7 @@ combine_chains <- function(res) {
 
 
 ## This is absolutely terrible, but it will get there.
-append_chains <- function(prev, curr, sampler) {
+append_chains <- function(prev, curr) {
   n_chains <- length(prev$restart$rng_state)
   i <- split(seq_along(prev$chain), prev$chain)
   j <- split(seq_along(curr$chain) + length(prev$chain), curr$chain)

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -117,7 +117,7 @@ mcstate_sampler_adaptive <- function(initial_vcv,
     internal$weight <- 0
     internal$iteration <- 0
 
-    internal$mean <- pars
+    internal$mean <- unname(pars)
     n_pars <- length(model$parameters)
     internal$autocorrelation <- matrix(0, n_pars, n_pars)
     internal$vcv <- update_vcv(internal$mean, internal$autocorrelation,

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -199,7 +199,7 @@ mcstate_sampler_adaptive <- function(initial_vcv,
           "scaling_history", "scaling_weight", "scaling_increment")]
   }
 
-  get_internal_state <- function(state, model, rng) {
+  get_internal_state <- function() {
     as.list(internal)
   }
 

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -17,7 +17,7 @@
 ##' the proposal is a multi-variate Normal distribution centered on the current
 ##' point.
 ##'
-##' Spencer SEF (2021) Accelerating adaptation in the adaptive 
+##' Spencer SEF (2021) Accelerating adaptation in the adaptive
 ##' Metropolis–Hastings random walk algorithm. Australian & New Zealand Journal
 ##' of Statistics 63:468-484.
 ##'
@@ -37,14 +37,14 @@
 ##'   covariance matrix to be used to generate the multivariate normal
 ##'   proposal for the random-walk Metropolis-Hastings algorithm. To generate
 ##'   the proposal matrix, the weighted variance covariance matrix is
-##'   multiplied by the scaling parameter squared times 2.38^2 / n_pars (where 
+##'   multiplied by the scaling parameter squared times 2.38^2 / n_pars (where
 ##'   n_pars is the number of fitted parameters). Thus, in a Gaussian target
 ##'   parameter space, the optimal scaling will be around 1.
 ##'
 ##' @param initial_scaling_weight The initial weight used in the scaling update.
 ##'   The scaling weight will increase after the first `pre_diminish`
 ##'   iterations, and as the scaling weight increases the adaptation of the
-##'   scaling diminishes. If `NULL` (the default) the value is 
+##'   scaling diminishes. If `NULL` (the default) the value is
 ##'   5 / (acceptance_target * (1 - acceptance_target)).
 ##'
 ##' @param min_scaling The minimum scaling of the variance covariance
@@ -55,34 +55,34 @@
 ##'   subtracted to the scaling factor of the variance-covariance
 ##'   after each adaptive step. If `NULL` (the default) then an optimal
 ##'   value will be calculated.
-##'   
+##'
 ##' @param log_scaling_update Logical, whether or not changes to the
 ##'   scaling parameter are made on the log-scale.
 ##'
 ##' @param acceptance_target The target for the fraction of proposals
 ##'   that should be accepted (optimally) for the adaptive part of the
 ##'   mixture model.
-##'   
-##' @param forget_rate The rate of forgetting early parameter sets from the 
+##'
+##' @param forget_rate The rate of forgetting early parameter sets from the
 ##'   empirical variance-covariance matrix in the MCMC chains. For example,
 ##'   `forget_rate = 0.2` (the default) means that once in every 5th iterations
 ##'   we remove the earliest parameter set included, so would remove the 1st
 ##'   parameter set on the 5th update, the 2nd on the 10th update, and so
 ##'   on. Setting `forget_rate = 0` means early parameter sets are never
 ##'   forgotten.
-##'   
+##'
 ##' @param forget_end The final iteration at which early parameter sets can
 ##'   be forgotten. Setting `forget_rate = Inf` (the default) means that the
 ##'   forgetting mechanism continues throughout the chains. Forgetting early
 ##'   parameter sets becomes less useful once the chains have settled into the
 ##'   posterior mode, so this parameter might be set as an estimate of how long
 ##'   that would take.
-##'   
+##'
 ##' @param adapt_end The final iteration at which we can adapt the multivariate
 ##'   normal proposal. Thereafter the empirical variance-covariance matrix, its
 ##'   scaling and its weight remain fixed. This allows the adaptation to be
 ##'   switched off at a certain point to help ensure convergence of the chain.
-##'   
+##'
 ##' @param pre_diminish The number of updates before adaptation of the scaling
 ##'   parameter starts to diminish. Setting `pre_diminish = 0` means there is
 ##'   diminishing adaptation of the scaling parameter from the offset, while
@@ -111,45 +111,43 @@ mcstate_sampler_adaptive <- function(initial_vcv,
   ## This sampler is stateful; we will be updating our estimate of the
   ## mean and vcv of the target distribution, along with the our
   ## scaling factor, weight and autocorrelations.
-  ##
-  ## Probably we will provide some method later for extracting this
-  ## internal state and dump it out at the end of the sampling (so
-  ## perhaps 'finalise') as I think we've previously collected this up
-  ## at the end of the sampling as the estimated vcv is of interest.
   internal <- new.env()
 
-  initialise <- function(state, model, rng) {
+  initialise <- function(pars, model, rng) {
     internal$weight <- 0
     internal$iteration <- 0
-    
-    internal$mean <- state$pars
+
+    internal$mean <- pars
     n_pars <- length(model$parameters)
     internal$autocorrelation <- matrix(0, n_pars, n_pars)
     internal$vcv <- update_vcv(internal$mean, internal$autocorrelation,
                                internal$weight)
-    
+
     internal$scaling <- initial_scaling
     internal$scaling_increment <- scaling_increment %||%
       calc_scaling_increment(n_pars, acceptance_target,
                              log_scaling_update)
     internal$scaling_weight <- initial_scaling_weight %||%
       5 / (acceptance_target * (1 - acceptance_target))
-    
+
     internal$history_pars <- numeric()
     internal$included <- integer()
     internal$scaling_history <- internal$scaling
+
+    density <- model$density(pars)
+    list(pars = pars, density = density)
   }
 
   step <- function(state, model, rng) {
-    proposal_vcv <- 
+    proposal_vcv <-
       calc_proposal_vcv(internal$scaling, internal$vcv, internal$weight,
                         initial_vcv, initial_vcv_weight)
-    
+
     pars_next <- rmvnorm(state$pars, proposal_vcv, rng)
 
     u <- rng$random_real(1)
     density_next <- model$density(pars_next)
-    
+
     accept_prob <- min(1, exp(density_next - state$density))
 
     accept <- u < accept_prob
@@ -159,17 +157,17 @@ mcstate_sampler_adaptive <- function(initial_vcv,
     }
 
     internal$iteration <- internal$iteration + 1
-    internal$history_pars <- rbind(internal$history_pars, state$pars) 
+    internal$history_pars <- rbind(internal$history_pars, state$pars)
     if (internal$iteration > adapt_end) {
       internal$scaling_history <- c(internal$scaling_history, internal$scaling)
       return(state)
     }
-    
+
     if (internal$iteration > pre_diminish) {
       internal$scaling_weight <- internal$scaling_weight + 1
     }
-    
-    is_replacement <- 
+
+    is_replacement <-
       check_replacement(internal$iteration, forget_rate, forget_end)
     if (is_replacement) {
       pars_remove <- internal$history_pars[internal$included[1L], ]
@@ -179,10 +177,10 @@ mcstate_sampler_adaptive <- function(initial_vcv,
       internal$included <- c(internal$included, internal$iteration)
       internal$weight <- internal$weight + 1
     }
-    
-    internal$scaling <- 
+
+    internal$scaling <-
       update_scaling(internal$scaling, internal$scaling_weight, accept_prob,
-                     internal$scaling_increment, min_scaling, acceptance_target, 
+                     internal$scaling_increment, min_scaling, acceptance_target,
                      log_scaling_update)
     internal$scaling_history <- c(internal$scaling_history, internal$scaling)
     internal$autocorrelation <- update_autocorrelation(
@@ -201,10 +199,20 @@ mcstate_sampler_adaptive <- function(initial_vcv,
           "scaling_history", "scaling_weight", "scaling_increment")]
   }
 
+  get_internal_state <- function(state, model, rng) {
+    as.list(internal)
+  }
+
+  set_internal_state <- function(state) {
+    list2env(state, internal)
+  }
+
   mcstate_sampler("Adaptive Metropolis-Hastings",
                   initialise,
                   step,
-                  finalise)
+                  finalise,
+                  get_internal_state,
+                  set_internal_state)
 }
 
 
@@ -212,14 +220,14 @@ calc_scaling_increment <- function(n_pars, acceptance_target,
                                    log_scaling_update) {
   if (log_scaling_update) {
     A <- -qnorm(acceptance_target / 2)
-    
-    scaling_increment <- 
-      (1 - 1 / n_pars) * (sqrt(2 * pi) * exp(A^2 / 2)) / (2 * A) + 
+
+    scaling_increment <-
+      (1 - 1 / n_pars) * (sqrt(2 * pi) * exp(A^2 / 2)) / (2 * A) +
       1 / (n_pars * acceptance_target * (1 - acceptance_target))
   } else {
     scaling_increment <- 1 / 100
   }
-  
+
   scaling_increment
 }
 
@@ -232,11 +240,11 @@ qp <- function(x) {
 calc_proposal_vcv <- function(scaling, vcv, weight, initial_vcv,
                               initial_vcv_weight) {
   n_pars <- nrow(vcv)
-  
+
   weighted_vcv <-
     ((weight - 1) * vcv + (initial_vcv_weight + n_pars + 1) * initial_vcv) /
     (weight + initial_vcv_weight + n_pars + 1)
-  
+
   2.38^2 / n_pars * scaling^2 * weighted_vcv
 }
 
@@ -245,7 +253,7 @@ check_replacement <- function(iteration, forget_rate, forget_end) {
   is_forget_step <- floor(forget_rate * iteration) >
     floor(forget_rate * (iteration - 1))
   is_before_forget_end <- iteration <= forget_end
-  
+
   is_forget_step & is_before_forget_end
 }
 
@@ -255,13 +263,13 @@ update_scaling <- function(scaling, scaling_weight, accept_prob,
                            acceptance_target, log_scaling_update) {
   scaling_change <- scaling_increment * (accept_prob - acceptance_target) /
     sqrt(scaling_weight)
-  
+
   if (log_scaling_update) {
     max(min_scaling, scaling * exp(scaling_change))
   } else {
     max(min_scaling, scaling + scaling_change)
   }
-  
+
 }
 
 
@@ -281,7 +289,7 @@ update_autocorrelation <- function(pars, weight, autocorrelation, pars_remove) {
       autocorrelation <- autocorrelation + qp(pars)
     }
   }
-  
+
   autocorrelation
 }
 
@@ -292,7 +300,7 @@ update_mean <- function(pars, weight, mean, pars_remove) {
   } else {
     mean <- (1 - 1 / weight) * mean + 1 / weight * pars
   }
-  
+
   mean
 }
 
@@ -303,6 +311,6 @@ update_vcv <- function(mean, autocorrelation, weight) {
   } else {
     vcv <- 0 * autocorrelation
   }
-  
+
   vcv
 }

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -131,7 +131,7 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
   }
 
   set_internal_state <- function(state) {
-    list2env(state, internal)
+    internal$history <- state$history
   }
 
   mcstate_sampler("Hamiltonian Monte Carlo",

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -126,10 +126,20 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
     }
   }
 
+  get_internal_state <- function() {
+    list(history = internal$history)
+  }
+
+  set_internal_state <- function(state) {
+    list2env(state, internal)
+  }
+
   mcstate_sampler("Hamiltonian Monte Carlo",
                   initialise,
                   step,
-                  finalise)
+                  finalise,
+                  get_internal_state,
+                  set_internal_state)
 }
 
 

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -28,7 +28,7 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
     check_vcv(vcv, call = environment())
   }
 
-  initialise <- function(state, model, rng) {
+  initialise <- function(pars, model, rng) {
     internal$transform <- hmc_transform(model$domain)
     n_pars <- length(model$parameters)
     if (is.null(vcv)) {
@@ -43,6 +43,8 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
     if (debug) {
       internal$history <- list()
     }
+    density <- model$density(pars)
+    list(pars = pars, density = density)
   }
 
   step <- function(state, model, rng) {

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -59,12 +59,22 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
     state
   }
 
+  ## These are all effectively the defaults:
   finalise <- function(state, model, rng) {
     NULL
+  }
+
+  get_internal_state <- function() {
+    NULL
+  }
+
+  set_internal_state <- function(state) {
   }
 
   mcstate_sampler("Random walk",
                   initialise,
                   step,
-                  finalise)
+                  finalise,
+                  get_internal_state,
+                  set_internal_state)
 }

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -31,9 +31,9 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
     proposal <- make_rmvnorm(vcv)
   }
 
-  initialise <- function(state, model, rng) {
+  initialise <- function(pars, model, rng) {
     if (!is.null(vcv)) {
-      n_pars <- length(state$pars)
+      n_pars <- length(model$parameters)
       n_vcv <- nrow(vcv)
       if (n_pars != n_vcv) {
         cli::cli_abort(
@@ -43,6 +43,9 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
     if (isTRUE(model$properties$is_stochastic)) {
       model$model$set_rng_state(rng)
     }
+
+    density <- model$density(pars)
+    list(pars = pars, density = density)
   }
 
   step <- function(state, model, rng) {

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -199,16 +199,6 @@ test_that("continuing requires that we have a samples object", {
 })
 
 
-test_that("can't append chains that have details", {
-  model <- ex_simple_gamma1()
-  sampler <- mcstate_sampler_random_walk(vcv = diag(1) * 0.01)
-  res <- mcstate_sample(model, sampler, 5, 1, restartable = TRUE)
-  res$details <- list()
-  expect_error(mcstate_sample_continue(res, 5),
-               "Can't yet merge chains with details")
-})
-
-
 test_that("generate initial conditions that fall within the domain", {
   x <- mcstate_rng$new(seed = 1)$normal(20, -2, 1)
   n <- which(x > 0)[1] # 5

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -65,3 +65,18 @@ test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
   expect_equal(res$details[[1]]$vcv, cov(res$pars[26:300,]),
                ignore_attr = TRUE)
 })
+
+
+test_that("can continue adaptive sampler", {
+  m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
+  sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)))
+
+  set.seed(1)
+  res1 <- mcstate_sample(m, sampler, 30, n_chains = 3, restartable = TRUE)
+
+  set.seed(1)
+  res2a <- mcstate_sample(m, sampler, 10, n_chains = 3, restartable = TRUE)
+  res2b <- mcstate_sample_continue(res2a, 20, restartable = TRUE)
+
+  expect_equal(res2b, res1)
+})

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -1,71 +1,67 @@
 test_that("Empirical VCV calculated correctly with forget_rate = 0", {
-  
   m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
-  
+
   sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
                                       forget_rate = 0,
                                       log_scaling_update = FALSE)
-  res <- mcstate_sample(m, sampler, 5000)
-  expect_equal(names(res), c("pars", "density", "details", "chain"))
-  
+  res <- mcstate_sample(m, sampler, 1000)
+  expect_equal(names(res), c("pars", "density", "initial", "details", "chain"))
+
   ## forget_rate = 0 so full chain should be included in VCV
-  expect_equal(res$details[[1]]$weight, 5000)
-  expect_equal(res$details[[1]]$included, seq_len(5000))
-  expect_equal(res$details[[1]]$vcv, cov(res$pars[2:5001,]), ignore_attr = TRUE)
-})  
-  
+  expect_equal(res$details[[1]]$weight, 1000)
+  expect_equal(res$details[[1]]$included, seq_len(1000))
+  expect_equal(res$details[[1]]$vcv, cov(res$pars), ignore_attr = TRUE)
+})
+
+
 test_that("Empirical VCV calculated correctly with forget_rate = 0.1", {
-  
   m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
-  
+
   sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
                                       forget_rate = 0.1)
-  res <- mcstate_sample(m, sampler, 5000)
-  expect_equal(names(res), c("pars", "density", "details", "chain"))
-  
-  ## forget_rate = 0.1 so VCV should exclude first 500 parameter sets
-  expect_equal(res$details[[1]]$weight, 4500)
-  expect_equal(res$details[[1]]$included, seq(501, 5000, by = 1))
-  expect_equal(res$details[[1]]$vcv, cov(res$pars[502:5001,]),
-               ignore_attr = TRUE)
-})  
-  
-test_that("Empirical VCV calculated correctly with forget_rate = 0.5 and
-          forget_end = 500", {
-  
-  m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
-  
-  sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
-                                      forget_rate = 0.5,
-                                      forget_end = 500)
-  res <- mcstate_sample(m, sampler, 5000)
-  expect_equal(names(res), c("pars", "density", "details", "chain"))
-  
-  ## forget_rate = 0.5 and forget_end = 500 so VCV should exclude first
-  ## 250 parameter sets
-  expect_equal(res$details[[1]]$weight, 4750)
-  expect_equal(res$details[[1]]$included, seq(251, 5000, by = 1))
-  expect_equal(res$details[[1]]$vcv, cov(res$pars[252:5001,]),
+  res <- mcstate_sample(m, sampler, 1000)
+  expect_equal(names(res), c("pars", "density", "initial", "details", "chain"))
+
+  ## forget_rate = 0.1 so VCV should exclude first 100 parameter sets
+  expect_equal(res$details[[1]]$weight, 900)
+  expect_equal(res$details[[1]]$included, seq(101, 1000, by = 1))
+  expect_equal(res$details[[1]]$vcv, cov(res$pars[101:1000, ]),
                ignore_attr = TRUE)
 })
 
-test_that("Empirical VCV calculated correctly with forget_rate = 0.25,
-          forget_end = 500 and adapt_end = 1000", {
-            
+
+test_that("Empirical VCV correct using both forget_rate and forget_end", {
   m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
-  
+
+  sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
+                                      forget_rate = 0.5,
+                                      forget_end = 200)
+  res <- mcstate_sample(m, sampler, 1000)
+  expect_equal(names(res), c("pars", "density", "initial", "details", "chain"))
+
+  ## forget_rate = 0.5 and forget_end = 200 so VCV should exclude first
+  ## 100 parameter sets
+  expect_equal(res$details[[1]]$weight, 900)
+  expect_equal(res$details[[1]]$included, seq(101, 1000, by = 1))
+  expect_equal(res$details[[1]]$vcv, cov(res$pars[101:1000,]),
+               ignore_attr = TRUE)
+})
+
+
+test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
+  m <- ex_simple_gaussian(vcv = rbind(c(0.02, 0.01), c(0.01, 0.03)))
+
   sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
                                       forget_rate = 0.25,
-                                      forget_end = 500,
-                                      adapt_end = 1000)
-  res <- mcstate_sample(m, sampler, 5000)
-  expect_equal(names(res), c("pars", "density", "details", "chain"))
-  
-  ## forget_rate = 0.25, forget_end = 500 and adapt_end = 100 so VCV should
-  ## only include parameter sets 126 to 1000
-  expect_equal(res$details[[1]]$weight, 875)
-  expect_equal(res$details[[1]]$included, seq(126, 1000, by = 1))
-  expect_equal(res$details[[1]]$vcv, cov(res$pars[127:1001,]),
+                                      forget_end = 100,
+                                      adapt_end = 300)
+  res <- mcstate_sample(m, sampler, 1000)
+  expect_equal(names(res), c("pars", "density", "initial", "details", "chain"))
+
+  ## forget_rate = 0.25, forget_end = 500 and adapt_end = 300 so VCV should
+  ## only include parameter sets 26 to 300
+  expect_equal(res$details[[1]]$weight, 275)
+  expect_equal(res$details[[1]]$included, seq(26, 300, by = 1))
+  expect_equal(res$details[[1]]$vcv, cov(res$pars[26:300,]),
                ignore_attr = TRUE)
-  
 })

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -115,3 +115,34 @@ test_that("prevent weird distributions", {
     hmc_transform(cbind(rep(0, 3), c(1, Inf, -Inf))),
     "Unhandled domain type for parameter 3")
 })
+
+
+test_that("can continue hmc without debug", {
+  m <- ex_simple_gaussian(diag(2))
+
+  set.seed(1)
+  sampler <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)
+  res1 <- mcstate_sample(m, sampler, 30, n_chains = 3, restartable = TRUE)
+
+  set.seed(1)
+  res2a <- mcstate_sample(m, sampler, 10, n_chains = 3, restartable = TRUE)
+  res2b <- mcstate_sample_continue(res2a, 20, restartable = TRUE)
+
+  expect_equal(res2b, res1)
+})
+
+
+test_that("can continue hmc with debug", {
+  m <- ex_simple_gaussian(diag(2))
+
+  set.seed(1)
+  sampler <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10,
+                                 debug = TRUE)
+  res1 <- mcstate_sample(m, sampler, 30, n_chains = 3, restartable = TRUE)
+
+  set.seed(1)
+  res2a <- mcstate_sample(m, sampler, 10, n_chains = 3, restartable = TRUE)
+  res2b <- mcstate_sample_continue(res2a, 20, restartable = TRUE)
+
+  expect_equal(res2b, res1)
+})

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -24,9 +24,9 @@ test_that("validate sampler against model on initialisation", {
   sampler1 <- mcstate_sampler_random_walk(vcv = diag(1) * 0.01)
   sampler2 <- mcstate_sampler_random_walk(vcv = diag(2) * 0.01)
 
-  expect_no_error(sampler1$initialise(state, m))
+  expect_no_error(sampler1$initialise(1, m))
   expect_error(
-    sampler2$initialise(state, m),
+    sampler2$initialise(1, m),
     "Incompatible length parameters (1) and vcv (2)",
     fixed = TRUE)
 })


### PR DESCRIPTION
This PR tidies up how samplers are started:

* e95d9a0 is a small fix that does something I keep wanting - we leave it up to the sampler to return the initial state (so given pars, return a list with pars/density). This is going to be nice once we get observer support and for nested models (with likelihoods that can be separated into different pieces)
* everything else is a larger set of changes that allows saving/loading of internal state from a sampler

After running a chain, in addition to dumping out the rng state we also dump out the sampler state (this is empty for the random walk sampler and just the debug information for the HMC sampler, but for the adaptive sampler in #15 it will be fairly complex).  We pass that back in to `mcstate_run_chain` (along with the rng state) when starting a chain and set that into the sampler after initialisation but before running.

Because the details come from the sampler itself, for appending chains we can just take details from the second sampler which will by then have the state that the combination would have had.

This is going to require a small amount of change to #15 (or this) depending on the merge order.

Looks like the build is broken after merging #15 without a rebase sorry, my fault. This PR is now slightly churny because I zapped trailing whitespace and toned down the number of iteration Ed was using in the tests from 5k to 1k to make it faster.