### PR TITLE
Add banana doc

### DIFF
--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -13,7 +13,7 @@
 ##'
 ##' Our implementation of an adaptive MCMC algorithm is based on an
 ##' adaptation of the "accelerated shaping" algorithm in Spencer (2021).
-##' The algorithm is based on a random-walk Metropolis-Hasting algorithm where
+##' The algorithm is based on a random-walk Metropolis-Hastings algorithm where
 ##' the proposal is a multi-variate Normal distribution centred on the current
 ##' point.
 ##'

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -14,7 +14,7 @@
 ##' Our implementation of an adaptive MCMC algorithm is based on an
 ##' adaptation of the "accelerated shaping" algorithm in Spencer (2021).
 ##' The algorithm is based on a random-walk Metropolis-Hasting algorithm where
-##' the proposal is a multi-variate Normal distribution centered on the current
+##' the proposal is a multi-variate Normal distribution centred on the current
 ##' point.
 ##'
 ##' Spencer SEF (2021) Accelerating adaptation in the adaptive

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -4,6 +4,7 @@ HPC
 OpenMP
 Poisson
 R's
+VCV
 codecov
 composable
 hyperthreading
@@ -15,6 +16,11 @@ pmcmc
 restartable
 rhyper
 rng
+sim
+Hasting
+SEF
+nd
 splitmix
+st
 stan
 th

--- a/man/mcstate_sampler_adaptive.Rd
+++ b/man/mcstate_sampler_adaptive.Rd
@@ -110,7 +110,7 @@ the MCMC.
 Our implementation of an adaptive MCMC algorithm is based on an
 adaptation of the "accelerated shaping" algorithm in Spencer (2021).
 The algorithm is based on a random-walk Metropolis-Hasting algorithm where
-the proposal is a multi-variate Normal distribution centered on the current
+the proposal is a multi-variate Normal distribution centred on the current
 point.
 
 Spencer SEF (2021) Accelerating adaptation in the adaptive

--- a/man/mcstate_sampler_adaptive.Rd
+++ b/man/mcstate_sampler_adaptive.Rd
@@ -109,7 +109,7 @@ the MCMC.
 
 Our implementation of an adaptive MCMC algorithm is based on an
 adaptation of the "accelerated shaping" algorithm in Spencer (2021).
-The algorithm is based on a random-walk Metropolis-Hasting algorithm where
+The algorithm is based on a random-walk Metropolis-Hastings algorithm where
 the proposal is a multi-variate Normal distribution centred on the current
 point.
 

--- a/vignettes/samplers.Rmd
+++ b/vignettes/samplers.Rmd
@@ -115,7 +115,7 @@ lines(z95[, 1], z95[, 2])
 
 As we can see this is not great.  We can probably improve the samples here by finding a better variance covariance matrix (VCV), but a single VCV will not hold well over the whole surface because it is not very similar to a multivariate normal (that is, the appropriate VCV will change depending on the position in parameter space)
 
-Let's try the Hamilton Monte Carlo (HMC) sampler, which uses the gradient to move efficiently in parameter space:
+Let's try the Hamiltonian Monte Carlo (HMC) sampler, which uses the gradient to move efficiently in parameter space:
 
 ```{r HMC_sampling}
 sampler_hmc <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)

--- a/vignettes/samplers.Rmd
+++ b/vignettes/samplers.Rmd
@@ -7,4 +7,121 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+set.seed(1)
+```
+
 This vignette will describe the samplers available in mcstate2.
+
+```{r}
+library(mcstate2)
+```
+
+# Comparisons
+
+## The bendy banana
+
+This example shows HMC outperforming a random walk on a two dimensional banana-shaped function.  Our model takes two parameters `alpha` and `beta`, and is based on two successive simple draws, with the one conditional on the other:
+￼
+\[
+\beta \sim Normal(1,0) \\
+\alpha \sim Normal(\beta^2, \sigma)
+\]
+￼
+with $\sigma$ the standard deviation of the conditional draw.
+
+We'll use R's `dnorm` for the likelihood calculations and then differentiate the density by hand (using the formula of the gaussian density) to derive the gradient by hand.  We skip the details here as this will be automated in an upcoming version of the package.
+￼
+```{r}
+banana_model <- function(sd = 0.5) {
+  mcstate_model(list(
+    parameters = c("alpha", "beta"),
+    direct_sample = function(rng) {
+      beta <- rng$random_normal(1)
+      alpha <- rng$normal(1, beta^2, sd)
+      c(alpha, beta)
+    },
+    density = function(x) {
+      alpha <- x[[1]]
+      beta <- x[[2]]
+      dnorm(beta, log = TRUE) + dnorm((alpha - beta^2) / sd, log = TRUE)
+    },
+    gradient = function(x) {
+      alpha <- x[[1]]
+      beta <- x[[2]]
+      c((beta^2 - alpha) / sd^2,
+        -beta + 2 * beta * (alpha - beta^2) / sd^2)
+    },
+    domain = rbind(c(-Inf, Inf), c(-Inf, Inf))))
+}
+```
+
+Let's create a model with $\sigma = 0.5$
+
+```{r create_banana_model}
+m <- banana_model(0.5)
+```
+
+We can plot a greyscale visualisation of its density by computing the density over a grid.  Normally this is not possible of course:
+
+```{r}
+a <- seq(-2, 6, length.out = 1000)
+b <- seq(-2, 2, length.out = 1000)
+z <- outer(a, b, function(a, b) dnorm(b) * dnorm((a - b^2) / 0.5))
+image(a, b, z, xlab = "alpha", ylab = "beta")
+```
+
+In this particular case we can also easily generate samples, so we know what a good sampler will produce:
+
+```{r}
+rng <- mcstate_rng$new()
+s <- vapply(seq(200), function(x) m$direct_sample(rng), numeric(2))
+image(a, b, z, xlab = "alpha", ylab = "beta")
+points(s[1, ], s[2, ], pch = 19, col = "#00000055")
+```
+
+It is also possible to compute the 95% confidence interval of the distribution using the relationship between the standard bivariate normal distribution and the banana shaped distribution as defined above. We can check than roughly 10 samples (out of 200) are out of this 95% CI contour.
+
+```{r}
+theta <- seq(0, 2 * pi, length.out = 10000)
+z95 <- local({
+  sd <- 0.5
+  r <- sqrt(qchisq(.95, df = 2))
+  x <- r * cos(theta)
+  y <- r * sin(theta)
+  cbind(x^2 + y * sd, x)
+})
+image(a, b, z, xlab = "alpha", ylab = "beta")
+lines(z95[, 1], z95[, 2])
+points(s[1, ], s[2, ], pch = 19, col = "#00000055")
+```
+
+## Sampling with other samplers
+
+It is not generally possible to directly sample from a density (otherwise MCMC and similar methods would not exist!).  In these cases we need to use a sampler based on the density and if available possibly the gradient of the density.
+
+We can start with a basic random-walk sampler
+
+```{r RW_sampling}
+sampler_rw <- mcstate_sampler_random_walk(vcv = diag(2) * 0.01)
+res_rw <- mcstate_sample(m, sampler_rw, 2000)
+plot(res_rw$pars, pch = 19, col = "#ff222277")
+lines(z95[, 1], z95[, 2])
+```
+
+As we can see this is not great.  We can probably improve the samples here by finding a better variance covariance matrix (VCV), but a single VCV will not hold well over the whole surface because it is not very similar to a multivariate normal (that is, the appropriate VCV will change depending on the position in parameter space)
+
+Let's try the Hamilton Monte Carlo (HMC) sampler, which uses the gradient to move efficiently in parameter space:
+
+```{r HMC_sampling}
+sampler_hmc <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)
+res_hmc <- mcstate_sample(m, sampler_hmc, 2000)
+plot(res_hmc$pars, pch = 19, col = "#ff222277")
+lines(z95[, 1], z95[, 2])
+```
+
+Clearly better!


### PR DESCRIPTION
This PR pulls in @MJomaba's banana Rmd doc into the nascent "samplers" vignette. More can be added later!

I've restructured the original a bit to make it a bit faster.  It does make me think that optionally being able to sample many points, or compute many densities, might be nicer.  But it will definitely complicate the interface with unexpected moves between vector and matrix return values.

Closes #11 