### PR TITLE
Import array utilities

### DIFF
--- a/R/arrays.R
+++ b/R/arrays.R
@@ -114,6 +114,43 @@ array_reshape <- function(x, i, d, call = NULL) {
 }
 
 
+array_drop <- function(x, i, call = NULL) {
+  dx <- dim2(x)
+  rank <- length(dx)
+  if (rank < max(i)) {
+    cli::cli_abort(
+      "Can't update dimension {max(i)}, array only has {rank} dimension{?s}",
+      call = call)
+  }
+  if (!all(dx[i] == 1)) {
+    err <- i[dx[i] != 1]
+    ## I can't make cli's pluralisation work here easily, doing that
+    ## manually:
+    if (length(err) == 1L) {
+      cli::cli_abort(
+        "Can't drop dimension {err} as it is length {dx[err]}, not 1",
+        call = call)
+    } else {
+      cli::cli_abort(
+        "Can't drop dimensions {err} as they are length {dx[err]}, not 1",
+        call = call)
+    }
+  }
+  dn <- dimnames(x)
+  dim(x) <- dim(x)[-i]
+  if (!is.null(dn)) {
+    if (rank == 2) {
+      x <- c(x)
+      names(x) <- dn[[-i]]
+    } else {
+      dimnames(x) <- dn[-i]
+    }
+  }
+  x
+}
+
+
+
 array_nth_dimension <- function(x, k, i) {
   rank <- length(dim2(x))
   if (k < 1 || k > rank) {

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -1,0 +1,171 @@
+array_bind <- function(..., arrays = list(...), on = NULL,
+                       before = NULL, after = NULL, call = NULL) {
+  if (length(arrays) == 0) {
+    cli::cli_abort("Must provide at least one array", call = call)
+  }
+  d <- check_ranks_same(
+    arrays,
+    "Can't bind these arrays together, they do not have the same rank",
+    call)
+  r <- nrow(d)
+
+  ## Allow one of on, before or after, then validate
+  ## these inputs (this is a bunch of work).
+  if ((!is.null(before)) + (!is.null(after)) + (!is.null(on)) > 1) {
+    cli::cli_abort(
+      "Only one of 'on', before' or 'after' may be given")
+  }
+  if (!is.null(after)) {
+    if (after < 1 || after > r) {
+      cli::cli_abort(
+        "Invalid value for 'after' ({after}), must be in [1, {r}]",
+        arg = "after", call = call)
+    }
+  } else if (!is.null(before)) {
+    if (before < 1 || before > r) {
+      cli::cli_abort(
+        "Invalid value for 'before' ({before}), must be in [1, {r}]",
+        arg = "before", call = call)
+    }
+  } else if (is.null(on)) {
+    on <- r
+  }
+
+  ## Then we need to check the shared dimensions
+  check_dimensions_same(
+    d, on,
+    "Can't bind these arrays together, their shared dimensions do not agree",
+    call)
+
+  ## Now, if we are not using 'on', we need to inflate all our arrays.
+  ## We could do this within the logic below but it really complicates
+  ## things.
+  if (is.null(on)) {
+    if (!is.null(after)) {
+      arrays <- lapply(arrays, array_reshape,
+                       after, c(d[after, 1], 1), call)
+      on <- after + 1L
+    } else {
+      arrays <- lapply(arrays, array_reshape,
+                       before, c(1, d[before, 1]), call)
+      on <- before
+    }
+    r <- r + 1L
+    d <- vapply(arrays, dim2, numeric(r))
+  }
+
+  n <- d[on, ]
+  d <- d[, 1]
+  d[[on]] <- sum(n)
+
+  if (on == r) {
+    ret <- array(unlist(arrays), d)
+  } else {
+    offset <- c(0, cumsum(n))
+    ret <- array(arrays[[1]][[1]] * NA, d)
+    idx <- array(seq_along(ret), d)
+    for (i in seq_along(arrays)) {
+      j <- seq_len(n[[i]]) + offset[[i]]
+      k <- c(array_nth_dimension(idx, on, j))
+      ret[k] <- c(arrays[[i]])
+    }
+  }
+
+  dn <- dimnames(arrays[[1]])
+  if (!is.null(dn)) {
+    dn_this <- lapply(arrays, function(x) dimnames(x)[[on]])
+    if (all(lengths(dn_this) > 0)) {
+      dn[[on]] <- unlist(dn_this)
+    } else {
+      dn[on] <- list(NULL)
+    }
+    dimnames(ret) <- dn
+  }
+
+  ret
+}
+
+
+array_reshape <- function(x, i, d, call = NULL) {
+  dx <- dim2(x)
+  if (length(dx) < i) {
+    cli::cli_abort(
+      "array only has {length(dx)} dimension{?s}, can't update dimension {i}",
+      call = call)
+  }
+  if (dx[[i]] != prod(d)) {
+    dim_str <- paste(d, collapse = ", ")
+    cli::cli_abort(
+      paste("New dimensions ({dim_str}) imply dimension {i} has length",
+            "{prod(d)} but found {dx[[i]]}"),
+      call = call)
+  }
+
+  dn <- dimnames(x)
+
+  ## The actual reshape is easy:
+  dim(x) <- append(dx[-i], d, i - 1L)
+
+  ## Can't preserve dimension names on modified dimensions
+  if (!is.null(dn)) {
+    dimnames(x) <- append(dn[-i], rep(list(NULL), length(d)), i - 1L)
+  }
+  x
+}
+
+
+array_nth_dimension <- function(x, k, i, drop = FALSE) {
+  rank <- length(dim(x))
+  if (rank == 2) {
+    expr <- quote(x[, , drop = FALSE])
+  } else if (rank == 3) {
+    expr <- quote(x[, , , drop = FALSE])
+  } else if (rank == 4) {
+    expr <- quote(x[, , , , drop = FALSE])
+  } else {
+    stop("Unexpected rank")
+  }
+  if (k < 1 || k > rank) {
+    stop(sprintf("'k' must be in [1, %d]", rank))
+  }
+
+  expr[[k + 2]] <- quote(i)
+  eval(expr)
+}
+
+
+check_dimensions_same <- function(d, ignore = NULL, message = NULL,
+                                  call = NULL) {
+  if (length(ignore) > 0) {
+    d[ignore, ] <- 0
+  }
+  d_diff <- d - d[, 1] != 0
+  if (any(d_diff)) {
+    r <- nrow(d)
+    err <- which(d_diff, TRUE)
+    err_dim <- unname(seq_len(r)[err[, 1]])
+    err_msg <- vcapply(split(err_dim, err[, 2]), paste, collapse = ", ")
+    detail <- sprintf("array %s (dimension %s)",
+                      names(err_msg), unname(err_msg))
+    cli::cli_abort(
+      c(message %||% "Incompatible dimension arrays",
+        set_names(detail, "*")),
+      call = call)
+  }
+}
+
+
+check_ranks_same <- function(arrays, message = NULL, call = call) {
+  d <- lapply(arrays, dim2)
+  r <- lengths(d)
+  err <- r != r[[1]]
+  if (any(err)) {
+    detail <- sprintf("array %d has rank %d", seq_along(r), r)
+    cli::cli_abort(
+      c(message %||% "Incompatible rank arrays",
+        set_names(detail, "*")),
+      call = call)
+  }
+  r <- r[[1]]
+  matrix(unlist(d), r)
+}

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -101,7 +101,7 @@ array_reshape <- function(x, i, d, call = NULL) {
       call = call)
   }
 
-  dn <- dimnames(x)
+  dn <- dimnames2(x)
 
   ## The actual reshape is easy:
   dim(x) <- append(dx[-i], d, i - 1L)
@@ -114,21 +114,20 @@ array_reshape <- function(x, i, d, call = NULL) {
 }
 
 
-array_nth_dimension <- function(x, k, i, drop = FALSE) {
-  rank <- length(dim(x))
-  if (rank == 2) {
-    expr <- quote(x[, , drop = FALSE])
-  } else if (rank == 3) {
-    expr <- quote(x[, , , drop = FALSE])
-  } else if (rank == 4) {
-    expr <- quote(x[, , , , drop = FALSE])
-  } else {
-    stop("Unexpected rank")
-  }
+array_nth_dimension <- function(x, k, i) {
+  rank <- length(dim2(x))
   if (k < 1 || k > rank) {
-    stop(sprintf("'k' must be in [1, %d]", rank))
+    cli::cli_abort("'k' must be in [1, {rank}]")
   }
-
+  expr <- switch(rank,
+                 quote(x[]),                           # 1
+                 quote(x[, , drop = FALSE]),           # 2
+                 quote(x[, , , drop = FALSE]),         # 3
+                 quote(x[, , , , drop = FALSE]),       # 4
+                 quote(x[, , , , , drop = FALSE]),     # 5
+                 quote(x[, , , , , , drop = FALSE]),   # 6
+                 quote(x[, , , , , , , drop = FALSE]), # 7
+                 cli::cli_abort("Unexpected rank")) # crazy stuff.
   expr[[k + 2]] <- quote(i)
   eval(expr)
 }

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -13,7 +13,7 @@ array_bind <- function(..., arrays = list(...), on = NULL,
   ## these inputs (this is a bunch of work).
   if ((!is.null(before)) + (!is.null(after)) + (!is.null(on)) > 1) {
     cli::cli_abort(
-      "Only one of 'on', before' or 'after' may be given")
+      "Only one of 'on', 'before' or 'after' may be given")
   }
   if (!is.null(after)) {
     if (after < 1 || after > r) {

--- a/R/util.R
+++ b/R/util.R
@@ -3,11 +3,6 @@
 }
 
 
-vlapply <- function(...) {
-  vapply(..., FUN.VALUE = logical(1))
-}
-
-
 check_vcv <- function(vcv, name = deparse(substitute(vcv)), call = NULL) {
   if (!is.matrix(vcv)) {
     cli::cli_abort("Expected '{name}' to be a matrix",
@@ -56,6 +51,11 @@ vnapply <- function(...) {
 }
 
 
+vcapply <- function(...) {
+  vapply(..., FUN.VALUE = "")
+}
+
+
 rbind_list <- function(x) {
   stopifnot(all(vlapply(x, is.matrix)))
   if (length(x) == 1) {
@@ -69,4 +69,18 @@ rbind_list <- function(x) {
 
 squote <- function(x) {
   sprintf("'%s'", x)
+}
+
+
+dim2 <- function(x) {
+  dim(x) %||% length(x)
+}
+
+
+set_names <- function(x, nms) {
+  if (length(nms) == 1 && length(x) != 1) {
+    nms <- rep_len(nms, length(x))
+  }
+  names(x) <- nms
+  x
 }

--- a/R/util.R
+++ b/R/util.R
@@ -77,6 +77,16 @@ dim2 <- function(x) {
 }
 
 
+dimnames2 <- function(x) {
+  if (!is.null(dim(x))) {
+    dimnames(x)
+  } else {
+    nms <- names(x)
+    if (is.null(nms)) NULL else list(nms)
+  }
+}
+
+
 set_names <- function(x, nms) {
   if (length(nms) == 1 && length(x) != 1) {
     nms <- rep_len(nms, length(x))

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -104,3 +104,15 @@ ex_banana <- function(sd = 0.5) {
     },
     domain = cbind(rep(-Inf, 2), rep(Inf, 2))))
 }
+
+
+random_array <- function(dim, named = FALSE) {
+  if (named) {
+    dn <- lapply(seq_along(dim), function(i)
+      paste0(LETTERS[[i]], letters[seq_len(dim[i])]))
+    names(dn) <- paste0("d", LETTERS[seq_along(dim)])
+  } else {
+    dn <- NULL
+  }
+  array(runif(prod(dim)), dim, dimnames = dn)
+}

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -130,3 +130,79 @@ test_that("trivial case", {
   expect_identical(array_bind(m4), m4)
   expect_error(array_bind(), "Must provide at least one array")
 })
+
+
+test_that("prevent conflicting arguments", {
+  m1 <- random_array(c(3, 5))
+  m2 <- random_array(c(3, 5))
+  expect_error(
+    array_bind(arrays = list(m1, m2), after = 1, before = 2),
+    "Only one of 'on', 'before' or 'after' may be given")
+  expect_error(
+    array_bind(arrays = list(m1, m2), after = 1, on = 2),
+    "Only one of 'on', 'before' or 'after' may be given")
+})
+
+
+test_that("binding after requires that the provided values are reasonable", {
+  m1 <- random_array(c(3, 5))
+  m2 <- random_array(c(3, 5))
+
+  expect_error(
+    array_bind(arrays = list(m1, m2), before = 3),
+    "Invalid value for 'before' (3), must be in [1, 2]",
+    fixed = TRUE)
+  expect_error(
+    array_bind(arrays = list(m1, m2), before = 0),
+    "Invalid value for 'before' (0), must be in [1, 2]",
+    fixed = TRUE)
+  expect_error(
+    array_bind(arrays = list(m1, m2), after = 3),
+    "Invalid value for 'after' (3), must be in [1, 2]",
+    fixed = TRUE)
+  expect_error(
+    array_bind(arrays = list(m1, m2), after = 0),
+    "Invalid value for 'after' (0), must be in [1, 2]",
+    fixed = TRUE)
+})
+
+
+test_that("Can get an arbitrary dimension of an array", {
+  m1 <- random_array(4)
+  expect_equal(array_nth_dimension(m1, 1, 2), m1[2])
+  expect_equal(array_nth_dimension(m1, 1, 2:3), m1[2:3])
+
+  m2 <- random_array(c(3, 5))
+  expect_equal(array_nth_dimension(m2, 2, 2), m2[, 2, drop = FALSE])
+  expect_equal(array_nth_dimension(m2, 2, 2:3), m2[, 2:3, drop = FALSE])
+
+  m3 <- random_array(c(3, 5, 7))
+  expect_equal(array_nth_dimension(m3, 2, 2), m3[, 2, , drop = FALSE])
+  expect_equal(array_nth_dimension(m3, 2, 2:3), m3[, 2:3, , drop = FALSE])
+
+  m4 <- random_array(c(3, 5, 7, 11))
+  expect_equal(array_nth_dimension(m4, 2, 2), m4[, 2, , , drop = FALSE])
+  expect_equal(array_nth_dimension(m4, 2, 2:3), m4[, 2:3, , , drop = FALSE])
+
+  m5 <- random_array(c(3, 5, 7, 5, 3))
+  expect_equal(array_nth_dimension(m5, 2, 2), m5[, 2, , , , drop = FALSE])
+  expect_equal(array_nth_dimension(m5, 2, 2:3), m5[, 2:3, , , , drop = FALSE])
+
+  m6 <- random_array(c(3, 5, 7, 5, 3, 5))
+  expect_equal(array_nth_dimension(m6, 2, 2), m6[, 2, , , , , drop = FALSE])
+  expect_equal(array_nth_dimension(m6, 2, 2:3), m6[, 2:3, , , , , drop = FALSE])
+
+  m7 <- random_array(c(3, 5, 7, 5, 3, 5, 7))
+  expect_equal(array_nth_dimension(m7, 2, 2),
+               m7[, 2, , , , , , drop = FALSE])
+  expect_equal(array_nth_dimension(m7, 2, 2:3),
+               m7[, 2:3, , , , , , drop = FALSE])
+
+  expect_error(
+    array_nth_dimension(array(0, rep(1, 8)), 2, 2),
+    "Unexpected rank")
+  expect_error(
+    array_nth_dimension(m2, 3, 2),
+    "'k' must be in [1, 2]",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -244,3 +244,9 @@ test_that("Prevent impossible drops", {
     "Can't drop dimensions 1 and 3 as they are length 5 and 10, not 1",
     fixed = TRUE)
 })
+
+
+test_that("preserve names dropping to vector", {
+  m2 <- random_array(c(5, 1))
+  dimnames(m2) <- list("x", letters[1:5])
+})

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -1,0 +1,132 @@
+test_that("reshape", {
+  m4 <- random_array(c(5, 7, 10, 13))
+  res <- array_reshape(m4, 3L, c(2, 5))
+  expect_equal(dim(res), c(5, 7, 2, 5, 13))
+  expect_equal(c(res), c(m4))
+
+  expect_equal(res[2, 2, , ,  2], matrix(m4[2, 2, , 2], 2, 5))
+
+  expect_error(
+    array_reshape(m4, 10, c(2, 5)),
+    "array only has 4 dimensions, can't update dimension 10")
+  expect_error(
+    array_reshape(m4, 3, c(2, 6)),
+    "New dimensions (2, 6) imply dimension 3 has length 12 but found 10",
+    fixed = TRUE)
+})
+
+
+test_that("reshape preserves dimnames where it can", {
+  m4 <- random_array(c(5, 7, 10, 13), TRUE)
+  res <- array_reshape(m4, 3L, c(2, 5))
+  expect_equal(dim(res), c(5, 7, 2, 5, 13))
+  expect_equal(dimnames(res),
+               c(dimnames(m4)[1:2],
+                 list(NULL, NULL),
+                 dimnames(m4)[4]))
+
+  dimnames(m4) <- NULL
+  rownames(m4) <- letters[1:5]
+  res <- array_reshape(m4, 3L, c(2, 5))
+  expect_equal(dim(res), c(5, 7, 2, 5, 13))
+  expect_equal(dimnames(res),
+               list(letters[1:5], NULL, NULL, NULL, NULL))
+})
+
+
+test_that("array_bind", {
+  m2 <- random_array(c(5, 10))
+
+  expect_identical(array_bind(m2[, 1:4], m2[, 5:10]), m2)
+
+  m3 <- random_array(c(5, 7, 10))
+  expect_identical(array_bind(m3[, , 1:4], m3[, , 5:10]), m3)
+
+  m4 <- random_array(c(5, 7, 3, 10))
+  expect_identical(array_bind(m4[, , , 1:4], m4[, , , 5:10]), m4)
+})
+
+
+test_that("array_bind on other dimensions", {
+  m2 <- random_array(c(10, 5))
+  expect_identical(array_bind(m2[1:4, ], m2[5:10, ], on = 1), m2)
+
+  m3 <- random_array(c(5, 7, 9))
+  expect_identical(array_bind(m3[1:2, , ], m3[3:5, , ], on = 1), m3)
+  expect_identical(array_bind(m3[, 1:3, ], m3[, 4:7, ], on = 2), m3)
+  expect_identical(array_bind(m3[, , 1:4], m3[, , 5:9], on = 3), m3)
+
+  m4 <- random_array(c(5, 7, 3, 10))
+  expect_identical(array_bind(m4[1:2, , , ], m4[3:5, , , ], on = 1), m4)
+})
+
+
+test_that("preserve dimension names on merge", {
+  drop_last_names <- function(m) {
+    dn <- dimnames(m)
+    dn[length(dn)] <- list(NULL)
+    dimnames(m) <- dn
+    m
+  }
+
+  m2 <- random_array(c(5, 10), TRUE)
+  expect_identical(array_bind(m2[, 1:4], m2[, 5:10]), m2)
+  expect_identical(array_bind(drop_last_names(m2[, 1:4]), m2[, 5:10]),
+                   drop_last_names(m2))
+  expect_identical(array_bind(m2[, 1:4], drop_last_names(m2[, 5:10])),
+                   drop_last_names(m2))
+
+  m3 <- random_array(c(5, 7, 10), TRUE)
+  expect_identical(array_bind(m3[, , 1:4], m3[, , 5:10]), m3)
+
+  m4 <- random_array(c(5, 7, 3, 10), TRUE)
+  expect_identical(array_bind(m4[, , , 1:4], m4[, , , 5:10]), m4)
+})
+
+
+test_that("Can't merge incompatible arrays", {
+  m4 <- random_array(c(5, 7, 3, 10))
+  expect_error(
+    array_bind(m4[, , , 1:4], m4[, , -1, 5:10]),
+    "array 2 (dimension 3)",
+    fixed = TRUE)
+  expect_error(
+    array_bind(m4[, , , 1:4], m4[-1, , , 1:4], m4[-1, -1, -1, 5:10]),
+    "array 2 \\(dimension 1\\).*array 3 \\(dimension 1, 2, 3\\)")
+  expect_error(
+    array_bind(m4[1:3, , , ], m4[1:3, , , -1], on = 1),
+    "array 2 (dimension 4)",
+    fixed = TRUE)
+  expect_error(
+    array_bind(m4[, , , 1:4], random_array(c(5, 7, 10))),
+    "Can't bind these arrays together, they do not have the same rank",
+    fixed = TRUE)
+})
+
+
+test_that("can bind together by adding a dimension", {
+  m1 <- random_array(c(3, 5))
+  m2 <- random_array(c(3, 5))
+
+  res1 <- array_bind(arrays = list(m1, m2), after = 1)
+  expect_equal(res1[, 1, ], m1)
+  expect_equal(res1[, 2, ], m2)
+  expect_equal(
+    array_bind(arrays = list(m1, m2), before = 2),
+    res1)
+
+  res2 <- array_bind(arrays = list(m1, m2), after = 2)
+  expect_equal(res2[, , 1], m1)
+  expect_equal(res2[, , 2], m2)
+
+  res3 <- array_bind(arrays = list(m1, m2), before = 1)
+  expect_equal(res3[1, , ], m1)
+  expect_equal(res3[2, , ], m2)
+})
+
+
+test_that("trivial case", {
+  m4 <- random_array(c(5, 7, 3, 10))
+  expect_identical(array_bind(m4), m4)
+  expect_error(array_bind(), "Must provide at least one array")
+})

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -206,3 +206,41 @@ test_that("Can get an arbitrary dimension of an array", {
     "'k' must be in [1, 2]",
     fixed = TRUE)
 })
+
+
+test_that("drop spare dimensions", {
+  m4 <- random_array(c(5, 1, 10, 1))
+  res1 <- array_drop(m4, 2)
+  expect_equal(c(m4), c(res1))
+  expect_equal(dim(res1), c(5, 10, 1))
+
+  res2 <- array_drop(m4, c(2, 4))
+  expect_equal(c(m4), c(res2))
+  expect_equal(dim(res2), c(5, 10))
+})
+
+
+test_that("preserve names when dropping dimensions", {
+  m4 <- random_array(c(5, 1, 10, 1), TRUE)
+  expect_equal(dimnames(array_drop(m4, 2)), dimnames(m4)[-2])
+  expect_equal(dimnames(array_drop(m4, c(2, 4))), dimnames(m4)[-c(2, 4)])
+})
+
+
+test_that("Prevent impossible drops", {
+  m4 <- random_array(c(5, 1, 10, 1))
+  expect_error(
+    array_drop(m4, c(2, 5)),
+    "Can't update dimension 5, array only has 4 dimensions")
+
+  expect_error(array_drop(m4, 1),
+               "Can't drop dimension 1 as it is length 5, not 1")
+  expect_error(
+    array_drop(m4, c(1, 3)),
+    "Can't drop dimensions 1 and 3 as they are length 5 and 10, not 1",
+    fixed = TRUE)
+  expect_error(
+    array_drop(m4, c(1, 2, 3)),
+    "Can't drop dimensions 1 and 3 as they are length 5 and 10, not 1",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -247,6 +247,7 @@ test_that("Prevent impossible drops", {
 
 
 test_that("preserve names dropping to vector", {
-  m2 <- random_array(c(5, 1))
+  m2 <- random_array(c(1, 5))
   dimnames(m2) <- list("x", letters[1:5])
+  expect_equal(array_drop(m2, 1), set_names(c(m2), letters[1:5]))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -29,3 +29,22 @@ test_that("can bind lists of matrices", {
   expect_equal(rbind_list(list(m1, m2)), rbind(m1, m2))
   expect_equal(rbind_list(list(m1, m2, m3)), rbind(m1, m2, m3))
 })
+
+
+test_that("can get generalised array dimensions", {
+  expect_equal(dim2(1:6), 6)
+  expect_equal(dim2(matrix(1:6, 2, 3)), c(2, 3))
+})
+
+
+test_that("can get generalised array names", {
+  v <- 1:6
+  m <- matrix(v, 2, 3)
+  expect_null(dimnames(v))
+  expect_null(dimnames(m))
+
+  names(v) <- letters[1:6]
+  dimnames(m) <- list(letters[1:2], letters[3:5])
+  expect_equal(dimnames2(v), list(letters[1:6]))
+  expect_equal(dimnames2(m), list(letters[1:2], letters[3:5]))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -40,8 +40,8 @@ test_that("can get generalised array dimensions", {
 test_that("can get generalised array names", {
   v <- 1:6
   m <- matrix(v, 2, 3)
-  expect_null(dimnames(v))
-  expect_null(dimnames(m))
+  expect_null(dimnames2(v))
+  expect_null(dimnames2(m))
 
   names(v) <- letters[1:6]
   dimnames(m) <- list(letters[1:2], letters[3:5])


### PR DESCRIPTION
This PR stands in the way of parameter refactoring, and pulls in (with light modification) the array utilities from mcstate.  These make doing some operations with arrays a little easier, but they are a bit of a handful tbh.  We will likely export these later (hence the fairly thorough error handling) but for now I just want them to be able to bind together and expand some arrays

* `array_bind`- I want this for binding arrays together as layers when combining chains (adding a dimension), and end-on-end when appending chains (lengthening an existing dimension)
* `array_reshape` - expands a dimension of an array to a different shape (used to convert a 2d array into a 3d array for example)

Original code here: https://github.com/mrc-ide/mcstate/blob/master/R/arrays.R

See https://github.com/mrc-ide/mcstate2/pull/22 for usage