### PR TITLE
Correctly restart stochastic models

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -14,8 +14,8 @@
 ##'   from the model.
 ##'
 ##' @param is_stochastic Logical, indicating if the model is
-##'   stochastic.  Stochastic models must supply a `set_rng_state`
-##'   method and we might support a `get_rng_state` method later.
+##'   stochastic.  Stochastic models must supply `set_rng_state` and
+##'   `get_rng_state` methods.
 ##'
 ##' @return A list of class `mcstate_model_properties` which should
 ##'   not be modified.
@@ -103,6 +103,9 @@ mcstate_model_properties <- function(has_gradient = NULL,
 ##'   otherwise you'll end up correlated with the draws from the
 ##'   sampler.
 ##'
+##' * `get_rng_state`: A function to get the RNG state; must be
+##'   provided if `set_rng_state` is present.
+##'
 ##' @title Create basic model
 ##'
 ##' @param model A list or environment with elements as described in
@@ -147,6 +150,7 @@ mcstate_model <- function(model, properties = NULL) {
               density = density,
               gradient = gradient,
               direct_sample = direct_sample,
+              rng_state = rng_state,
               properties = properties)
   class(ret) <- "mcstate_model"
   ret
@@ -251,6 +255,7 @@ validate_model_rng_state <- function(model, properties, call) {
   if (is.null(properties$is_stochastic) && is.null(model$set_rng_state)) {
     return(NULL)
   }
+  ## TODO: this now needs more complex logic, really.
   if (!is.function(model$set_rng_state)) {
     if (isTRUE(properties$is_stochastic)) {
       hint <- paste("You have specified 'is_stochastic = TRUE', so in order",
@@ -266,7 +271,8 @@ validate_model_rng_state <- function(model, properties, call) {
         i = hint),
       arg = "model", call = call)
   }
-  list(set = model$set_rng_state)
+  list(set = model$set_rng_state,
+       get = model$get_rng_state)
 }
 
 

--- a/R/model.R
+++ b/R/model.R
@@ -294,3 +294,27 @@ require_direct_sample <- function(model, message, ...) {
       ...)
   }
 }
+
+
+require_deterministic <- function(model, message, ...) {
+  if (model$properties$is_stochastic) {
+    cli::cli_abort(
+      c(message,
+        i = paste("This model is stochastic (its 'is_stochastic' property",
+                  "is TRUE) so cannot be used in contexts that require",
+                  "a deterministic density")),
+      ...)
+  }
+}
+
+
+require_gradient <- function(model, message, ...) {
+  if (!model$properties$has_gradient) {
+    cli::cli_abort(
+      c(message,
+        i = paste("This model does not provide a gradient (its 'has_gradient'",
+                  "property is FALSE) so cannot be used in contexts that",
+                  "require one")),
+      ...)
+  }
+}

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -114,6 +114,8 @@ mcstate_sampler_adaptive <- function(initial_vcv,
   internal <- new.env()
 
   initialise <- function(pars, model, rng) {
+    require_deterministic(model,
+                          "Can't use adaptive sampler with stochastic models")
     internal$weight <- 0
     internal$iteration <- 0
 

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -134,8 +134,7 @@ mcstate_sampler_adaptive <- function(initial_vcv,
     internal$included <- integer()
     internal$scaling_history <- internal$scaling
 
-    density <- model$density(pars)
-    list(pars = pars, density = density)
+    initialise_state(pars, model, rng)
   }
 
   step <- function(state, model, rng) {

--- a/R/sampler-helpers.R
+++ b/R/sampler-helpers.R
@@ -1,0 +1,7 @@
+initialise_state <- function(pars, model, rng) {
+  if (isTRUE(model$properties$is_stochastic)) {
+    model$rng_state$set(mcstate_rng$new(rng$state())$jump()$state())
+  }
+  density <- model$density(pars)
+  list(pars = pars, density = density)
+}

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -29,6 +29,9 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
   }
 
   initialise <- function(pars, model, rng) {
+    require_deterministic(model, "Can't use HMC with stochastic models")
+    require_gradient(model, "Can't use HMC without a gradient")
+
     internal$transform <- hmc_transform(model$domain)
     n_pars <- length(model$parameters)
     if (is.null(vcv)) {

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -43,8 +43,7 @@ mcstate_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
     if (debug) {
       internal$history <- list()
     }
-    density <- model$density(pars)
-    list(pars = pars, density = density)
+    initialise_state(pars, model, rng)
   }
 
   step <- function(state, model, rng) {

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -40,12 +40,7 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
           "Incompatible length parameters ({n_pars}) and vcv ({n_vcv})")
       }
     }
-    if (isTRUE(model$properties$is_stochastic)) {
-      model$rng_state$set(rng)
-    }
-
-    density <- model$density(pars)
-    list(pars = pars, density = density)
+    initialise_state(pars, model, rng)
   }
 
   step <- function(state, model, rng) {

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -41,7 +41,7 @@ mcstate_sampler_random_walk <- function(proposal = NULL, vcv = NULL) {
       }
     }
     if (isTRUE(model$properties$is_stochastic)) {
-      model$model$set_rng_state(rng)
+      model$rng_state$set(rng)
     }
 
     density <- model$density(pars)

--- a/man/mcstate_model.Rd
+++ b/man/mcstate_model.Rd
@@ -97,5 +97,7 @@ that is if you need multiple (perhaps parallel) streams of
 random numbers in your model.  The \verb{$jump()} is very important,
 otherwise you'll end up correlated with the draws from the
 sampler.
+\item \code{get_rng_state}: A function to get the RNG state; must be
+provided if \code{set_rng_state} is present.
 }
 }

--- a/man/mcstate_model.Rd
+++ b/man/mcstate_model.Rd
@@ -86,18 +86,12 @@ streams).  Models that provide this method are assumed to be
 stochastic; however, you can use the \code{is_stochastic} property
 (via \code{\link[=mcstate_model_properties]{mcstate_model_properties()}}) to override this (e.g., to
 run a stochastic model with its deterministic expectation).
-This function takes an \link{mcstate_rng} object and uses it to seed
-the random number state for your model.  You have two options
-here (1) hold a copy of the provided object and draw samples
-from it as needed (in effect sharing the random number stream
-with the sampler) or create a new rng stream from a jump with
-this stream (we'll provide a utility for doing this but at
-present doing \code{mcstate_rng$new(rng$state(), n_streams)$jump()$state()} will do).  The main reason you'd do
-that is if you need multiple (perhaps parallel) streams of
-random numbers in your model.  The \verb{$jump()} is very important,
-otherwise you'll end up correlated with the draws from the
-sampler.
+This function takes a raw vector of random number state from
+\link{mcstate_rng} and uses it to set the random number state for
+your model; this is derived from the random number stream for a
+particular chain, jumped ahead.
 \item \code{get_rng_state}: A function to get the RNG state; must be
-provided if \code{set_rng_state} is present.
+provided if \code{set_rng_state} is present.  Must return the random
+number state, which is a raw vector (potentially quite long).
 }
 }

--- a/man/mcstate_model_properties.Rd
+++ b/man/mcstate_model_properties.Rd
@@ -20,8 +20,8 @@ the model.}
 from the model.}
 
 \item{is_stochastic}{Logical, indicating if the model is
-stochastic.  Stochastic models must supply a \code{set_rng_state}
-method and we might support a \code{get_rng_state} method later.}
+stochastic.  Stochastic models must supply \code{set_rng_state} and
+\code{get_rng_state} methods.}
 }
 \value{
 A list of class \code{mcstate_model_properties} which should

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -63,8 +63,16 @@ ex_dust_sir <- function(n_particles = 100, n_threads = 1,
   }
 
   set_rng_state <- function(rng) {
-    state <- mcstate_rng$new(rng$state(), n_particles + 1)$jump()$state()
+    if (inherits(rng, "mcstate_rng")) {
+      state <- mcstate_rng$new(rng$state(), n_particles + 1)$jump()$state()
+    } else {
+      state <- rng
+    }
     model$set_rng_state(state)
+  }
+
+  get_rng_state <- function() {
+    model$rng_state()
   }
 
   mcstate_model(
@@ -72,7 +80,8 @@ ex_dust_sir <- function(n_particles = 100, n_threads = 1,
          direct_sample = direct_sample,
          parameters = c("beta", "gamma"),
          domain = cbind(c(0, 0), c(Inf, Inf)),
-         set_rng_state = set_rng_state),
+         set_rng_state = set_rng_state,
+         get_rng_state = get_rng_state),
     mcstate_model_properties(is_stochastic = !deterministic))
 }
 

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -62,13 +62,14 @@ ex_dust_sir <- function(n_particles = 100, n_threads = 1,
       rng$gamma(1, prior_gamma_shape, 1 / prior_gamma_rate))
   }
 
-  set_rng_state <- function(rng) {
-    if (inherits(rng, "mcstate_rng")) {
-      state <- mcstate_rng$new(rng$state(), n_particles + 1)$jump()$state()
-    } else {
-      state <- rng
+  set_rng_state <- function(rng_state) {
+    n_streams <- n_particles + 1
+    if (length(rng_state) != 32 * n_streams) {
+      ## Expand the state by short jumps; we'll make this nicer once
+      ## we refactor the RNG interface and dust.
+      rng_state <- mcstate_rng$new(rng_state, n_streams)$state()
     }
-    model$set_rng_state(state)
+    model$set_rng_state(rng_state)
   }
 
   get_rng_state <- function() {

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -132,22 +132,34 @@ test_that("stochastic models need an rng setting function", {
     mcstate_model(
       list(density = identity, parameters = "a"),
       mcstate_model_properties(is_stochastic = TRUE)),
-    "Expected 'model$set_rng_state' to be a function",
+    "Expected 'model$set_rng_state' and 'model$get_rng_state' to be functions",
     fixed = TRUE)
   expect_error(
     mcstate_model(
-      list(density = identity, parameters = "a", set_rng_state = TRUE)),
-    "Expected 'model$set_rng_state' to be a function",
+      list(density = identity, parameters = "a", set_rng_state = identity),
+      mcstate_model_properties(is_stochastic = TRUE)),
+    "Expected 'model$get_rng_state' to be a function",
     fixed = TRUE)
   expect_error(
     mcstate_model(
-      list(density = identity, parameters = "a", set_rng_state = TRUE),
+      list(density = identity, parameters = "a", get_rng_state = identity),
       mcstate_model_properties(is_stochastic = TRUE)),
     "Expected 'model$set_rng_state' to be a function",
     fixed = TRUE)
+
+  m <- list(density = identity, parameters = "a", set_rng_state = TRUE,
+            get_rng_state = identity)
+  expect_error(
+    mcstate_model(m),
+    "Expected 'model$set_rng_state' to be a function",
+    fixed = TRUE)
+  expect_error(
+    mcstate_model(m,
+                  mcstate_model_properties(is_stochastic = TRUE)),
+    "Expected 'model$set_rng_state' to be a function",
+    fixed = TRUE)
   expect_no_error(
-    res <- mcstate_model(
-      list(density = identity, parameters = "a", set_rng_state = TRUE),
-      mcstate_model_properties(is_stochastic = FALSE)))
+    res <- mcstate_model(m,
+                         mcstate_model_properties(is_stochastic = FALSE)))
   expect_null(res$set_rng_state)
 })

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -264,3 +264,22 @@ test_that("error if initial conditions do not have finite density", {
   expect_error(mcstate_sample(m, sampler, 100),
                "Chain does not have finite starting density")
 })
+
+
+test_that("can continue a stochastic model identically", {
+  set.seed(1)
+  model <- ex_dust_sir()
+  vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
+  sampler <- mcstate_sampler_random_walk(vcv = vcv)
+  initial <- c(0.2, 0.1)
+
+  set.seed(1)
+  res1 <- mcstate_sample(model, sampler, 10, initial, n_chains = 2)
+
+  set.seed(1)
+  res2a <- mcstate_sample(model, sampler, 2, initial, n_chains = 2,
+                          restartable = TRUE)
+  res2b <- mcstate_sample_continue(res2a, 8)
+
+  expect_equal(res2b, res1)
+})

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -84,3 +84,13 @@ test_that("can continue adaptive sampler", {
 
   expect_equal(res2b, res1)
 })
+
+
+test_that("can't use adaptive sampler with stochastic models", {
+  set.seed(1)
+  m <- ex_dust_sir()
+  sampler <- mcstate_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)))
+  expect_error(
+    mcstate_sample(m, sampler, 30, n_chains = 3),
+    "Can't use adaptive sampler with stochastic models")
+})

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -149,3 +149,23 @@ test_that("can continue hmc with debug", {
 
   expect_equal(res2b, res1)
 })
+
+
+test_that("can't use hmc with models that lack gradients", {
+  m <- mcstate_model(list(density = function(x) dnorm(x, log = TRUE),
+                          parameters = "a"))
+  sampler <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)
+  expect_error(
+    mcstate_sample(m, sampler, 30, 1, n_chains = 3),
+    "Can't use HMC without a gradient")
+})
+
+
+test_that("can't use hmc with stochastic models", {
+  set.seed(1)
+  m <- ex_dust_sir()
+  sampler <- mcstate_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)
+  expect_error(
+    mcstate_sample(m, sampler, 30, n_chains = 3),
+    "Can't use HMC with stochastic models")
+})


### PR DESCRIPTION
More bits found while trying to get ready to run observers.

This PR will allow stochastic models to be correctly restarted. This requires that we pull the rng state from the model at the end of running the chain and saving that into the restart data.  This ended up being quite fiddly (81340df) but is not actually a lot of code.  The test in 903e808 failed before this change because the model rng was re-seeded from the chain rng, which is actually pretty terrible as then we reuse a bunch of the same rng chain as before!

With this in, I've made the decision to simplify how model rng setting needs to happen; we now require a raw vector (see the doc change).  This then results in a nice symmetry with getting the rng state at the end of the simulation.

I've then had to change the example a bit, and the validation in model.R has got a bit uglier.  I don't like `mcstate_run_chain2` but don't have any better ideas right now (it's internal only and we can change this whenever).  But very happy to change here

Also notice checks added to the hmc and adaptive samplers that check that they can actually sample from the model provided; these fell through the gaps between PRs earlier.