### PR TITLE
Allow continuing parallel chains

### DIFF
--- a/R/runner.R
+++ b/R/runner.R
@@ -95,15 +95,19 @@ mcstate_runner_parallel <- function(n_workers) {
       MoreArgs = args)
   }
 
-  continue <- function(state, model, sampler, n_steps) {
+  continue <- function(state, model, sampler, observer, n_steps) {
     n_chains <- length(state)
     cl <- parallel::makeCluster(min(n_chains, n_workers))
     on.exit(parallel::stopCluster(cl))
+    args <- list(model = model,
+                 sampler = sampler,
+                 observer = observer,
+                 n_steps = n_steps)
     parallel::clusterMap(
       cl,
       mcstate_continue_chain,
       state,
-      MoreArgs = list(model = model, sampler = sampler, n_steps = n_steps))
+      MoreArgs = args)
   }
 
   structure(list(run = run, continue = continue),

--- a/R/runner.R
+++ b/R/runner.R
@@ -94,7 +94,20 @@ mcstate_runner_parallel <- function(n_workers) {
       rng = rng_state,
       MoreArgs = args)
   }
-  structure(list(run = run), class = "mcstate_runner")
+
+  continue <- function(state, model, sampler, n_steps) {
+    n_chains <- length(state)
+    cl <- parallel::makeCluster(min(n_chains, n_workers))
+    on.exit(parallel::stopCluster(cl))
+    parallel::clusterMap(
+      cl,
+      mcstate_continue_chain,
+      state,
+      MoreArgs = list(model = model, sampler = sampler, n_steps = n_steps))
+  }
+
+  structure(list(run = run, continue = continue),
+            class = "mcstate_runner")
 }
 
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -111,11 +111,24 @@ mcstate_sample <- function(model, sampler, n_steps, initial = NULL,
 ##'
 ##' @param n_steps The number of new steps to run
 ##'
+##' @param runner Optionally, a runner for your chains.  The default
+##'   is to continue with the backend that you used to start the
+##'   chains via [mcstate_sample] (or on the previous restart with
+##'   this function).  You can use this argument to change the runner,
+##'   which might be useful if transferring a pilot run from a
+##'   high-resource environment to a lower-resource environment.  If
+##'   given, must be an `mcstate_runner` object such as
+##'   [mcstate_runner_serial] or [mcstate_runner_parallel].  You can
+##'   use this argument to change the configuration of a runner, as
+##'   well as the type of runner (e.g., changing the number of
+##'   allocated cores).
+##'
 ##' @inheritParams mcstate_sample
 ##'
 ##' @return A list of parameters and densities
 ##' @export
-mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
+mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE,
+                                    runner = NULL) {
   if (!inherits(samples, "mcstate_samples")) {
     cli::cli_abort("Expected 'samples' to be an 'mcstate_samples' object")
   }
@@ -126,7 +139,12 @@ mcstate_sample_continue <- function(samples, n_steps, restartable = FALSE) {
                   "use the argument 'restartable = TRUE' when calling",
                   "mcstate_sample()")))
   }
-  runner <- samples$restart$runner
+
+  if (is.null(runner)) {
+    runner <- samples$restart$runner
+  } else {
+    assert_is(runner, "mcstate_runner")
+  }
   state <- samples$restart$state
   model <- samples$restart$model
   sampler <- samples$restart$sampler

--- a/man/mcstate_sample_continue.Rd
+++ b/man/mcstate_sample_continue.Rd
@@ -4,7 +4,7 @@
 \alias{mcstate_sample_continue}
 \title{Continue sampling}
 \usage{
-mcstate_sample_continue(samples, n_steps, restartable = FALSE)
+mcstate_sample_continue(samples, n_steps, restartable = FALSE, runner = NULL)
 }
 \arguments{
 \item{samples}{A \code{mcstate_samples} object created by
@@ -15,6 +15,18 @@ mcstate_sample_continue(samples, n_steps, restartable = FALSE)
 \item{restartable}{Logical, indicating if the chains should be
 restartable.  This will add additional data to the chains
 object.}
+
+\item{runner}{Optionally, a runner for your chains.  The default
+is to continue with the backend that you used to start the
+chains via \link{mcstate_sample} (or on the previous restart with
+this function).  You can use this argument to change the runner,
+which might be useful if transferring a pilot run from a
+high-resource environment to a lower-resource environment.  If
+given, must be an \code{mcstate_runner} object such as
+\link{mcstate_runner_serial} or \link{mcstate_runner_parallel}.  You can
+use this argument to change the configuration of a runner, as
+well as the type of runner (e.g., changing the number of
+allocated cores).}
 }
 \value{
 A list of parameters and densities

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -304,3 +304,29 @@ test_that("can continue parallel runs", {
 
   expect_equal(res2b, res1)
 })
+
+
+test_that("can change runner on restart", {
+  model <- ex_simple_gamma1()
+  sampler <- mcstate_sampler_random_walk(vcv = diag(1) * 0.01)
+
+  set.seed(1)
+  res1 <- mcstate_sample(model, sampler, 100, 1, n_chains = 3)
+
+  runner_parallel <- mcstate_runner_parallel(2)
+  runner_serial <- mcstate_runner_serial()
+
+  set.seed(1)
+  res2a <- mcstate_sample(model, sampler, 20, 1, n_chains = 3,
+                         restartable = TRUE)
+  res2b <- mcstate_sample_continue(res2a, 30, restartable = TRUE,
+                                   runner = runner_parallel)
+  res2c <- mcstate_sample_continue(res2b, 40, restartable = TRUE,
+                                   runner = runner_serial)
+  res2d <- mcstate_sample_continue(res2c, 10)
+
+  expect_identical(res2b$restart$runner, runner_parallel)
+  expect_identical(res2c$restart$runner, runner_serial)
+
+  expect_equal(res2d, res1)
+})

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -286,3 +286,21 @@ test_that("can continue a stochastic model identically", {
 
   expect_equal(res2b, res1)
 })
+
+
+test_that("can continue parallel runs", {
+  model <- ex_simple_gamma1()
+  sampler <- mcstate_sampler_random_walk(vcv = diag(1) * 0.01)
+
+  set.seed(1)
+  res1 <- mcstate_sample(model, sampler, 100, 1, n_chains = 3)
+
+  set.seed(1)
+  runner <- mcstate_runner_parallel(2)
+  res2a <- mcstate_sample(model, sampler, 50, 1, n_chains = 3,
+                          runner = runner, restartable = TRUE)
+  expect_identical(res2a$restart$runner, runner)
+  res2b <- mcstate_sample_continue(res2a, 50)
+
+  expect_equal(res2b, res1)
+})


### PR DESCRIPTION
Small missing feature for the (doomed) parallel runner; continue chains that were started in parallel.

I've folded in an additional small feature which allows the runner to be changed at restart.