### PR TITLE
Add support for progress bars

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,4 +24,3 @@
 ^_pkgdown\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
-

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,6 @@
 ^\.github$
 \.*gcov$
 ^_pkgdown\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$
+

--- a/R/progress.R
+++ b/R/progress.R
@@ -1,0 +1,73 @@
+progress_bar <- function(n_chains, n_steps, progress, call = NULL) {
+  progress <- show_progress_bar(progress, call)
+  if (progress) {
+    progress_bar_detail(n_chains, n_steps)
+  } else {
+    progress_bar_null()
+  }
+}
+
+
+show_progress_bar <- function(progress, call = NULL) {
+  if (is.null(progress)) {
+    progress <- getOption("mcstate2.progress", cli::is_dynamic_tty())
+  }
+  ## Error here is not great if we get this from an option; but need
+  ## to disable quoting there in some cases.
+  assert_scalar_logical(progress, call = call)
+}
+
+
+## This will be the case to use where we can report back in detail
+## about what is running (for each chain we can report about the
+## progress within that chain).  The other likely option will be a
+## very coarse detail which is the state of each chain only; that
+## might be the best we can do for some of the other parallel
+## backends, but we'll see how packages that implement progress bars
+## there cope.
+progress_bar_detail <- function(n_chains, n_steps) {
+  e <- new.env()
+  e$n <- rep(0, n_chains)
+
+  sym <- unlist(cli::symbol[paste0("lower_block_", 1:8)], use.names = FALSE)
+  at <- seq(0, n_steps, length.out = length(sym))
+  ## It would be much better to look up the theme here really, and use
+  ## colours from that, but I'm not totally sure what the mechanism is
+  ## for that.  Doing it the theme way will result in darl/light
+  ## appropriate colours being picked automatically which would be
+  ## nice.
+  col_running <- cli::make_ansi_style("orange")
+  col_finished <- cli::make_ansi_style("green")
+
+  overall <- function() {
+    ret <- sym[findInterval(e$n, at)]
+    i_finished <- e$n == n_steps
+    i_running <- !i_finished & e$n > 0
+    ret[i_finished] <- col_finished(ret[i_finished])
+    ret[i_running] <- col_running(ret[i_running])
+    paste0(ret, collapse = "")
+  }
+
+  fmt <- paste("Sampling [{overall()}] {cli::pb_bar} |",
+               "{cli::pb_percent} ETA: {cli::pb_eta}")
+  id <- cli::cli_progress_bar(
+    total = n_chains * n_steps,
+    format = fmt,
+    .auto_close = FALSE)
+
+  function(chain_index) {
+    function(at) {
+      e$n[[chain_index]] <- at
+      cli::cli_progress_update(id = id, set = sum(e$n))
+    }
+  }
+}
+
+
+## Dummy version that can be used where no progress bar is wanted.
+progress_bar_null <- function(...) {
+  function(chain_index) {
+    function(at) {
+    }
+  }
+}

--- a/R/progress.R
+++ b/R/progress.R
@@ -28,27 +28,8 @@ show_progress_bar <- function(progress, call = NULL) {
 progress_bar_detail <- function(n_chains, n_steps) {
   e <- new.env()
   e$n <- rep(0, n_chains)
-
-  sym <- unlist(cli::symbol[paste0("lower_block_", 1:8)], use.names = FALSE)
-  at <- seq(0, n_steps, length.out = length(sym))
-  ## It would be much better to look up the theme here really, and use
-  ## colours from that, but I'm not totally sure what the mechanism is
-  ## for that.  Doing it the theme way will result in darl/light
-  ## appropriate colours being picked automatically which would be
-  ## nice.
-  col_running <- cli::make_ansi_style("orange")
-  col_finished <- cli::make_ansi_style("green")
-
-  overall <- function() {
-    ret <- sym[findInterval(e$n, at)]
-    i_finished <- e$n == n_steps
-    i_running <- !i_finished & e$n > 0
-    ret[i_finished] <- col_finished(ret[i_finished])
-    ret[i_running] <- col_running(ret[i_running])
-    paste0(ret, collapse = "")
-  }
-
-  fmt <- paste("Sampling [{overall()}] {cli::pb_bar} |",
+  overall <- progress_overall(n_chains, n_steps)
+  fmt <- paste("Sampling {overall(e$n)} {cli::pb_bar} |",
                "{cli::pb_percent} ETA: {cli::pb_eta}")
   id <- cli::cli_progress_bar(
     total = n_chains * n_steps,
@@ -69,5 +50,29 @@ progress_bar_null <- function(...) {
   function(chain_index) {
     function(at) {
     }
+  }
+}
+
+
+progress_overall <- function(n_chains, n_steps) {
+  if (n_chains == 1) {
+    return(function(n) "")
+  }
+  sym <- unlist(cli::symbol[paste0("lower_block_", 1:8)], use.names = FALSE)
+  at <- seq(0, n_steps, length.out = length(sym))
+  ## It would be much better to look up the theme here really, and use
+  ## colours from that, but I'm not totally sure what the mechanism is
+  ## for that.  Doing it the theme way will result in darl/light
+  ## appropriate colours being picked automatically which would be
+  ## nice.
+  col_running <- cli::make_ansi_style("orange")
+  col_finished <- cli::make_ansi_style("green")
+  function(n) {
+    ret <- sym[findInterval(n, at)]
+    i_finished <- n == n_steps
+    i_running <- !i_finished & n > 0
+    ret[i_finished] <- col_finished(ret[i_finished])
+    ret[i_running] <- col_running(ret[i_running])
+    paste0(c("[", ret, "]"), collapse = "")
   }
 }

--- a/R/progress.R
+++ b/R/progress.R
@@ -10,7 +10,7 @@ progress_bar <- function(n_chains, n_steps, progress, call = NULL) {
 
 show_progress_bar <- function(progress, call = NULL) {
   if (is.null(progress)) {
-    progress <- getOption("mcstate2.progress", cli::is_dynamic_tty())
+    progress <- getOption("mcstate2.progress", TRUE)
   }
   ## Error here is not great if we get this from an option; but need
   ## to disable quoting there in some cases.

--- a/R/runner.R
+++ b/R/runner.R
@@ -122,7 +122,8 @@ mcstate_runner_parallel <- function(n_workers) {
     args <- list(model = model,
                  sampler = sampler,
                  observer = observer,
-                 n_steps = n_steps)
+                 n_steps = n_steps,
+                 progress = function(i) NULL)
     parallel::clusterMap(
       cl,
       mcstate_continue_chain,

--- a/R/runner.R
+++ b/R/runner.R
@@ -6,11 +6,11 @@
 ##'
 ##' @param progress Optional logical, indicating if we should print a
 ##'   progress bar while running.  If `NULL`, we use the value of the
-##'   option `mcstate2.progress` if set, otherwise we display a
-##'   progress bar if the terminal is dynamic (using
-##'   `cli::is_dynamic_tty`).  The progress bar itself responds to
-##'   cli's options; in particular `cli.progress_show_after` and
-##'   `cli.progress_clear` will affect your experience.
+##'   option `mcstate2.progress` if set, otherwise we show the
+##'   progress bar (as it is typically wanted).  The progress bar
+##'   itself responds to cli's options; in particular
+##'   `cli.progress_show_after` and `cli.progress_clear` will affect
+##'   your experience.
 ##'
 ##' @return A runner of class `mcstate_runner` that can be passed to
 ##'   [mcstate_sample()]

--- a/R/runner.R
+++ b/R/runner.R
@@ -28,7 +28,7 @@ mcstate_runner_serial <- function(progress = NULL) {
       })
   }
 
-  continue <- function(state, model, sampler, n_steps) {
+  continue <- function(state, model, sampler, observer, n_steps) {
     n_chains <- length(state)
     pb <- progress_bar(n_chains, n_steps, progress, environment())
     lapply(
@@ -143,7 +143,8 @@ mcstate_run_chain_parallel <- function(pars, model, sampler, observer,
 }
 
 
-mcstate_run_chain <- function(pars, model, sampler, n_steps, progress, rng) {
+mcstate_run_chain <- function(pars, model, sampler, observer, n_steps,
+                              progress, rng) {
   r_rng_state <- get_r_rng_state()
   chain_state <- sampler$initialise(pars, model, observer, rng)
 

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -22,7 +22,7 @@ assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
 assert_logical <- function(x, name = deparse(substitute(x)),
                           arg = name, call = NULL) {
   if (!is.logical(x)) {
-    cli::cli_abort("Exected '{name}' to be logical", arg = arg, call = call)
+    cli::cli_abort("Expected '{name}' to be logical", arg = arg, call = call)
   }
   invisible(x)
 }
@@ -31,7 +31,7 @@ assert_logical <- function(x, name = deparse(substitute(x)),
 assert_character <- function(x, name = deparse(substitute(x)),
                              arg = name, call = NULL) {
   if (!is.character(x)) {
-    cli::cli_abort("'{name}' must be character", call = call, arg = arg)
+    cli::cli_abort("Expected '{name}' to be character", call = call, arg = arg)
   }
   invisible(x)
 }
@@ -40,7 +40,7 @@ assert_character <- function(x, name = deparse(substitute(x)),
 assert_nonmissing <- function(x, name = deparse(substitute(x)),
                           arg = name, call = NULL) {
   if (anyNA(x)) {
-    cli::cli_abort("Exected '{name}' to be non-NA", arg = arg, call = call)
+    cli::cli_abort("Expected '{name}' to be non-NA", arg = arg, call = call)
   }
   invisible(x)
 }

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -39,7 +39,7 @@ assert_character <- function(x, name = deparse(substitute(x)),
 
 assert_nonmissing <- function(x, name = deparse(substitute(x)),
                           arg = name, call = NULL) {
-  if (!anyNA(x)) {
+  if (anyNA(x)) {
     cli::cli_abort("Exected '{name}' to be non-NA", arg = arg, call = call)
   }
   invisible(x)

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -19,6 +19,15 @@ assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
 }
 
 
+assert_logical <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = NULL) {
+  if (!is.logical(x)) {
+    cli::cli_abort("Exected '{name}' to be logical", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
 assert_character <- function(x, name = deparse(substitute(x)),
                              arg = name, call = NULL) {
   if (!is.character(x)) {
@@ -28,10 +37,28 @@ assert_character <- function(x, name = deparse(substitute(x)),
 }
 
 
+assert_nonmissing <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = NULL) {
+  if (!anyNA(x)) {
+    cli::cli_abort("Exected '{name}' to be non-NA", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_logical <- function(x, name = deparse(substitute(x)),
+                                  arg = name, call = NULL) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_logical(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
 assert_scalar_character <- function(x, name = deparse(substitute(x)),
                                     arg = name, call = NULL) {
   assert_scalar(x, name, arg = arg, call = call)
   assert_character(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
 }
 
 

--- a/man/mcstate_runner_serial.Rd
+++ b/man/mcstate_runner_serial.Rd
@@ -4,7 +4,16 @@
 \alias{mcstate_runner_serial}
 \title{Run MCMC chain in series}
 \usage{
-mcstate_runner_serial()
+mcstate_runner_serial(progress = NULL)
+}
+\arguments{
+\item{progress}{Optional logical, indicating if we should print a
+progress bar while running.  If \code{NULL}, we use the value of the
+option \code{mcstate2.progress} if set, otherwise we show the
+progress bar (as it is typically wanted).  The progress bar
+itself responds to cli's options; in particular
+\code{cli.progress_show_after} and \code{cli.progress_clear} will affect
+your experience.}
 }
 \value{
 A runner of class \code{mcstate_runner} that can be passed to

--- a/mcstate2.Rproj
+++ b/mcstate2.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,4 @@
+withr::local_options(
+  mcstate.progress = FALSE,
+  .local_envir = teardown_env()
+)

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -17,3 +17,39 @@ test_that("can select sensible values for progress", {
     expect_true(show_progress_bar(NULL))
   })
 })
+
+
+test_that("null progress bar does nothing", {
+  p <- progress_bar(10, 10, FALSE)(1)
+  expect_silent(p(1))
+})
+
+
+test_that("can format overall progress", {
+  withr::local_options(cli.num_colors = 1)
+  overall <- progress_overall(4, 100)
+  expect_equal(
+    overall(c(100, 30, 10, 0)),
+    paste0("[",
+           cli::symbol$lower_block_8,
+           cli::symbol$lower_block_3,
+           cli::symbol$lower_block_1,
+           cli::symbol$lower_block_1,
+           "]"))
+  expect_equal(
+    overall(c(100, 30, 10, 100)),
+    paste0("[",
+           cli::symbol$lower_block_8,
+           cli::symbol$lower_block_3,
+           cli::symbol$lower_block_1,
+           cli::symbol$lower_block_8,
+           "]"))
+})
+
+
+test_that("overall progress is empty with one chain", {
+  overall <- progress_overall(1, 100)
+  expect_equal(overall(0), "")
+  expect_equal(overall(50), "")
+  expect_equal(overall(100), "")
+})

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,0 +1,19 @@
+test_that("can select sensible values for progress", {
+  withr::with_options(list(mcstate2.progress = TRUE), {
+    expect_false(show_progress_bar(FALSE))
+    expect_true(show_progress_bar(TRUE))
+    expect_true(show_progress_bar(NULL))
+  })
+
+  withr::with_options(list(mcstate2.progress = FALSE), {
+    expect_false(show_progress_bar(FALSE))
+    expect_true(show_progress_bar(TRUE))
+    expect_false(show_progress_bar(NULL))
+  })
+
+  withr::with_options(list(mcstate2.progress = NULL), {
+    expect_false(show_progress_bar(FALSE))
+    expect_true(show_progress_bar(TRUE))
+    expect_true(show_progress_bar(NULL))
+  })
+})

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -19,6 +19,14 @@ test_that("assert_logical", {
 })
 
 
+test_that("assert_nonmissing", {
+  expect_silent(assert_nonmissing(TRUE))
+  expect_error(assert_nonmissing(NA), "Expected 'NA' to be non-NA")
+  x <- c(1, NA)
+  expect_error(assert_nonmissing(x), "Expected 'x' to be non-NA")
+})
+
+
 test_that("match_value", {
   expect_error(match_value("foo", letters), "must be one of")
   expect_silent(match_value("a", letters))

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -7,8 +7,15 @@ test_that("assert_scalar", {
 
 test_that("assert_character", {
   expect_silent(assert_character("a"))
-  expect_error(assert_character(1), "must be character")
-  expect_error(assert_character(TRUE), "must be character")
+  expect_error(assert_character(1), "to be character")
+  expect_error(assert_character(TRUE), "to be character")
+})
+
+
+test_that("assert_logical", {
+  expect_silent(assert_logical(TRUE))
+  expect_error(assert_logical(1), "Expected '1' to be logical")
+  expect_error(assert_logical("a"), "Expected '\"a\"' to be logical")
 })
 
 


### PR DESCRIPTION
Create a fairly informative progress bar that shows how each chain, and the overall sampling process, is going.  I've got a small set of vertical bars (one per chain) and a big bar that shows the total sampling progress.  The underlying progress printing machinery will be repurposable for the callr-based parallel runner similar to what we use in mcstate1 at which point it will look slightly more interesting.  I think this is better than one bar per chain in order as the thing that the user cares about is "when is this going to end" and the bar and ETA here capture that more closely.

Code to experiment:

```{r}
options(cli.progress_show_after = 0)
set.seed(1)
m <- ex_dust_sir()
vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
sampler <- mcstate_sampler_random_walk(vcv = vcv)
res <- mcstate_sample(m, sampler, 500, n_chains = 4)
```

producing

![progress](https://github.com/mrc-ide/mcstate2/assets/1558093/3c676678-95c1-4715-9b2a-36b34a821532)

Scattered thoughts:

* I'm not 100% certain that this should be an argument to the runner (though it is a property of the runner) and not the sample function, but that's easily changed later and the intent is really that people don't change this very much anyway.
* I've added an Rstudio project
* We depend on global options now (boo) and we need a test setup.R file to stop progress bars making a mess of test output, but I'll get these collected into a doc eventually, similar to what we have in [hipercow](https://mrc-ide.github.io/hipercow/articles/details.html#options)
* there's a bit of noise here with adding assertions etc; there is more to do here on other branches (see #27 for similar code)