### PR TITLE
Parse basic dsl

### DIFF
--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -1,0 +1,87 @@
+dsl_parse <- function(exprs) {
+  exprs <- lapply(exprs, dsl_parse_expr)
+
+  type <- vcapply(exprs, "[[", "type")
+  parameters <- vcapply(exprs[type == "stochastic"], "[[", "name")
+  if (anyDuplicated(parameters)) {
+    ## TODO: much better error here.
+    cli::cli_abort("Duplicated parameters")
+  }
+
+  ## TODO: check arguments to calls, perhaps simplest to disallow for now?
+
+  list(parameters = parameters, exprs = exprs)
+}
+
+
+dsl_parse_expr <- function(expr) {
+  if (rlang::is_call(expr, "~")) {
+    dsl_parse_expr_stochastic(expr)
+  } else if (rlang::is_call(expr, c("<-", "="))) {
+    dsl_parse_expr_assignment(expr)
+  } else {
+    dsl_parse_error(
+      "Unhandled expression; expected something involving '~' or '<-'",
+      expr)
+  }
+}
+
+
+dsl_parse_expr_stochastic <- function(expr) {
+  lhs <- expr[[2]]
+  if (!rlang::is_symbol(lhs)) {
+    ## TODO: once we support array expressions this will be relaxed a
+    ## little to allow lhs to be 'symbol[index]'
+    dsl_parse_error("Expected lhs of '~' relationship to be a symbol", expr)
+  }
+  rhs <- expr[[3]]
+
+  ## TODO: this will be derived from source of truth soon:
+  supported <- c("Normal", "Exponential", "Uniform")
+  if (!rlang::is_call(rhs, supported)) {
+    dsl_parse_error(
+      "Expected rhs of '~' relationship to be a call to a distribution")
+  }
+
+  ## Here we might check the arguments to the distribution functions,
+  ## too, but that's also easy enough to do elsewhere.
+  list(type = "stochastic",
+       name = as.character(lhs),
+       distribution = as.character(rhs[[1]]),
+       args = as.list(rhs[-1]),
+       expr = expr)
+}
+
+
+dsl_parse_expr_assignment <- function(expr) {
+  lhs <- expr[[2]]
+  if (!rlang::is_symbol(lhs)) {
+    ## TODO: once we support array expressions this will be relaxed a
+    ## little to allow lhs to be 'symbol[index]'
+    dsl_parse_error("Expected lhs of assignment to be a symbol", expr)
+  }
+  list(type = "assignment",
+       name = as.character(lhs),
+       expr = expr)
+}
+
+
+dsl_parse_error <- function(msg, expr) {
+  str <- attr(expr, "str", exact = TRUE)
+  if (is.null(str)) {
+    detail <- deparse(expr)
+  } else {
+    ## We can adjust the formatting here later, but this will
+    ## hopefully be fairly nice for users.
+    lines <- seq(attr(expr, "line"), length.out = length(str))
+    detail <- sprintf("%s| %s", cli::col_grey(format(lines)), str)
+  }
+  ## Using rlang::abort directly because whitespace will be important
+  ## here.
+  ##
+  ## The other way to do this is to implement cnd_body methods for
+  ## this class, but the effect will be similar.
+  rlang::abort(c(msg, set_names(detail, " ")), mcstate2_expr = expr,
+               class = "mcstate2_parse_error",
+               call = NULL)
+}

--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -48,7 +48,7 @@ dsl_parse_expr_stochastic <- function(expr) {
 
   ## This probably requires a little more care in order to know that
   ## we're not picking up too much or too little.  I'm not sure that
-  ## we can cope with every experssion here too as I think we also
+  ## we can cope with every expression here too as I think we also
   ## need to be able to invert the expressions?
   depends <- all.vars(rhs)
 
@@ -169,7 +169,7 @@ dsl_parse_check_usage <- function(exprs) {
         context <- NULL
       }
       ## TODO: It would be nice to indicate that we want to highlight
-      ## the varibles 'err' here within the expression; that is
+      ## the variables 'err' here within the expression; that is
       ## probably something rlang can do for us as it does that with
       ## the 'arg' argument to rlang::abort already?
       dsl_parse_error("Invalid use of variable{?s} {squote(err)}",

--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -1,14 +1,11 @@
 dsl_parse <- function(exprs) {
   exprs <- lapply(exprs, dsl_parse_expr)
 
-  type <- vcapply(exprs, "[[", "type")
-  parameters <- vcapply(exprs[type == "stochastic"], "[[", "name")
-  if (anyDuplicated(parameters)) {
-    ## TODO: much better error here.
-    cli::cli_abort("Duplicated parameters")
-  }
+  dsl_parse_check_duplicates(exprs)
+  dsl_parse_check_usage(exprs)
 
-  ## TODO: check arguments to calls, perhaps simplest to disallow for now?
+  name <- vcapply(exprs, "[[", "name")
+  parameters <- name[vcapply(exprs, "[[", "type") == "stochastic"]
 
   list(parameters = parameters, exprs = exprs)
 }
@@ -36,12 +33,24 @@ dsl_parse_expr_stochastic <- function(expr) {
   }
   rhs <- expr[[3]]
 
-  ## TODO: this will be derived from source of truth soon:
+  ## TODO: this will be derived from source of truth soon; we'll need
+  ## to also provide information about what distributions are
+  ## supported too; I'll do that on the next PR as it will be a bit
+  ## complicated most likely and start intersecting with what
+  ## distributions we aim to support. At that point we'll do a better
+  ## error.
   supported <- c("Normal", "Exponential", "Uniform")
   if (!rlang::is_call(rhs, supported)) {
     dsl_parse_error(
-      "Expected rhs of '~' relationship to be a call to a distribution")
+      "Expected rhs of '~' relationship to be a call to a distribution",
+      expr)
   }
+
+  ## This probably requires a little more care in order to know that
+  ## we're not picking up too much or too little.  I'm not sure that
+  ## we can cope with every experssion here too as I think we also
+  ## need to be able to invert the expressions?
+  depends <- all.vars(rhs)
 
   ## Here we might check the arguments to the distribution functions,
   ## too, but that's also easy enough to do elsewhere.
@@ -49,6 +58,7 @@ dsl_parse_expr_stochastic <- function(expr) {
        name = as.character(lhs),
        distribution = as.character(rhs[[1]]),
        args = as.list(rhs[-1]),
+       depends = depends,
        expr = expr)
 }
 
@@ -60,13 +70,48 @@ dsl_parse_expr_assignment <- function(expr) {
     ## little to allow lhs to be 'symbol[index]'
     dsl_parse_error("Expected lhs of assignment to be a symbol", expr)
   }
+  rhs <- expr[[3]]
+  ## I suspect we'll need to be quite restrictive about what
+  ## expressions are possible, but for now nothing special is done.
+  depends <- all.vars(rhs)
   list(type = "assignment",
        name = as.character(lhs),
+       depends = depends,
+       rhs = rhs,
        expr = expr)
 }
 
 
-dsl_parse_error <- function(msg, expr) {
+dsl_parse_error <- function(msg, expr, ..., envir = parent.frame(),
+                            call = NULL) {
+  cli::cli_abort(msg,
+                 ...,
+                 expr = expr,
+                 footer = dsl_parse_error_show_context,
+                 .envir = envir,
+                 class = "mcstate2_parse_error",
+                 call = call)
+}
+
+
+dsl_parse_error_show_context <- function(cnd, ...) {
+  detail <- c(">" = "In expression",
+              format_error_expr(cnd$expr))
+  for (i in seq_along(cnd$context)) {
+    detail <- c(detail,
+                "",
+                i = names(cnd$context)[[i]],
+                format_error_expr(cnd$context[[i]]))
+  }
+  ## Annoyingly, there's no way of marking text as whitespace
+  ## preserving within cli, so we need to do a substitution here for
+  ## "nonbreaking space" which does ok.  We should also convert tabs
+  ## to some number of spaces, probably.
+  gsub(" ", "\u00a0", detail)
+}
+
+
+format_error_expr <- function(expr) {
   str <- attr(expr, "str", exact = TRUE)
   if (is.null(str)) {
     detail <- deparse(expr)
@@ -74,14 +119,61 @@ dsl_parse_error <- function(msg, expr) {
     ## We can adjust the formatting here later, but this will
     ## hopefully be fairly nice for users.
     lines <- seq(attr(expr, "line"), length.out = length(str))
-    detail <- sprintf("%s| %s", cli::col_grey(format(lines)), str)
+    detail <- sprintf("%s| %s", cli::col_grey(format(lines, width = 3)), str)
   }
-  ## Using rlang::abort directly because whitespace will be important
-  ## here.
-  ##
-  ## The other way to do this is to implement cnd_body methods for
-  ## this class, but the effect will be similar.
-  rlang::abort(c(msg, set_names(detail, " ")), mcstate2_expr = expr,
-               class = "mcstate2_parse_error",
-               call = NULL)
+  detail
+}
+
+
+dsl_parse_check_duplicates <- function(exprs) {
+  type <- vcapply(exprs, "[[", "type")
+  name <- vcapply(exprs, "[[", "name")
+  i_err <- anyDuplicated(name)
+  if (i_err > 0) {
+    name_err <- name[[i_err]]
+    i_prev <- which(name == name_err)[[1]]
+    if (type[[i_err]] == type[[i_prev]]) {
+      if (type[[i_err]] == "stochastic") {
+        msg <- "Duplicated relationship '{name_err}'"
+      } else {
+        msg <- "Duplicated assignment '{name_err}'"
+      }
+    } else {
+      if (type[[i_err]] == "stochastic") {
+        msg <- "Relationship '{name_err}' shadows previous assignment"
+      } else {
+        msg <- "Assignment '{name_err}' shadows previous relationship"
+      }
+    }
+    context <- list("Previous definition" = exprs[[i_prev]]$expr)
+    dsl_parse_error(msg, exprs[[i_err]]$expr, context = context)
+  }
+}
+
+
+dsl_parse_check_usage <- function(exprs) {
+  name <- vcapply(exprs, "[[", "name")
+  for (i in seq_along(exprs)) {
+    e <- exprs[[i]]
+    err <- setdiff(e$depends, name[seq_len(i - 1)])
+    if (length(err) > 0) {
+      ## Out of order:
+      out_of_order <- intersect(name, err)
+      if (length(out_of_order) > 0) {
+        context <- lapply(exprs[name %in% out_of_order], "[[", "expr")
+        names(context) <- sprintf("'%s' is defined later:", out_of_order)
+      } else {
+        ## Could also tell the user about variables found in the
+        ## calling env, but that requires detecting and then passing
+        ## through the correct environment.
+        context <- NULL
+      }
+      ## TODO: It would be nice to indicate that we want to highlight
+      ## the varibles 'err' here within the expression; that is
+      ## probably something rlang can do for us as it does that with
+      ## the 'arg' argument to rlang::abort already?
+      dsl_parse_error("Invalid use of variable{?s} {squote(err)}",
+                      e$expr, context = context)
+    }
+  }
 }

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -41,3 +41,15 @@ mcstate_dsl <- function(x, type = NULL) {
   exprs <- dsl_preprocess(x, type)
   NULL
 }
+
+
+mcstate_dsl_parse <- function(x, type = NULL) {
+  quo <- rlang::enquo(x)
+  if (rlang::quo_is_symbol(quo)) {
+    x <- rlang::eval_tidy(quo)
+  } else {
+    x <- rlang::quo_get_expr(quo)
+  }
+  exprs <- dsl_preprocess(x, type)
+  dsl_parse(exprs)
+}

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -39,6 +39,7 @@ mcstate_dsl <- function(x, type = NULL) {
     x <- rlang::quo_get_expr(quo)
   }
   exprs <- dsl_preprocess(x, type)
+  dat <- dsl_parse(exprs)
   NULL
 }
 

--- a/tests/testthat/test-dsl-parse.R
+++ b/tests/testthat/test-dsl-parse.R
@@ -2,9 +2,9 @@ test_that("can throw sensible errors with expression information", {
   expr <- structure(quote(a + b), line = 10, str = "a+b")
   msg <- "some error message"
   err <- expect_error(dsl_parse_error(msg, expr), "some error message")
-  expect_equal(err$mcstate2_expr, expr)
+  expect_equal(err$expr, expr)
   expect_match(cli::ansi_strip(conditionMessage(err)),
-               "10| a+b", fixed = TRUE)
+               "In expression\n 10| a+b", fixed = TRUE)
 })
 
 
@@ -12,9 +12,7 @@ test_that("can throw sensible errors without expression information", {
   expr <- quote(a + b)
   msg <- "some error message"
   err <- expect_error(dsl_parse_error(msg, expr), "some error message")
-  expect_equal(err$mcstate2_expr, expr)
-  expect_match(cli::ansi_strip(conditionMessage(err)),
-               "a + b", fixed = TRUE)
+  expect_equal(err$expr, expr)
 })
 
 
@@ -42,12 +40,100 @@ test_that("can parse two-parameter model", {
 
 test_that("can parse model with expressions", {
   res <- mcstate_dsl_parse({
-    sd <- sqrt(pi)
+    sd <- sqrt(10)
     a ~ Normal(0, sd)
   })
   expect_equal(res$parameters, "a")
   expect_length(res$exprs, 2)
   expect_equal(res$exprs,
-               list(dsl_parse_expr_assignment(quote(sd <- sqrt(pi))),
+               list(dsl_parse_expr_assignment(quote(sd <- sqrt(10))),
                     dsl_parse_expr_stochastic(quote(a ~ Normal(0, sd)))))
+})
+
+
+test_that("prevent models that imply duplicated parameters", {
+  res <- expect_error(
+    mcstate_dsl("a~Normal(0,1)\na  ~  Uniform( 0,  1 )"),
+    "Duplicated relationship 'a'")
+  expect_equal(res$expr,
+               structure(quote(a ~ Uniform(0, 1)),
+                         line = 2, str = "a  ~  Uniform( 0,  1 )"))
+  expect_equal(names(res$context), "Previous definition")
+  expect_equal(res$context[[1]],
+               structure(quote(a ~ Normal(0, 1)),
+                         line = 1, str = "a~Normal(0,1)"))
+})
+
+
+test_that("variables are not used out of order", {
+  res <- expect_error(
+    mcstate_dsl({
+      b <- Normal(a, 1)
+      a <- Normal(0, 1)
+    }),
+    "Invalid use of variable 'a'")
+  expect_equal(res$expr, quote(b <- Normal(a, 1)))
+  expect_equal(res$context,
+               list("'a' is defined later:" = quote(a <- Normal(0, 1))))
+})
+
+
+test_that("variables must be defined somewhere", {
+  res <- expect_error(
+    mcstate_dsl({
+      a <- Normal(0, 1)
+      b <- Normal(a, sd)
+    }),
+    "Invalid use of variable 'sd'")
+  expect_equal(res$expr, quote(b <- Normal(a, sd)))
+})
+
+
+test_that("require that stochastic relationships assign to a symbol", {
+  expect_error(
+    dsl_parse_expr_stochastic(quote(f(a) ~ Normal(0, 1))),
+    "Expected lhs of '~' relationship to be a symbol")
+  expect_error(
+    dsl_parse_expr_stochastic(quote(1 ~ Normal(0, 1))),
+    "Expected lhs of '~' relationship to be a symbol")
+})
+
+
+test_that("require that stochastic relationships use known distributions", {
+  expect_error(
+    dsl_parse_expr_stochastic(quote(a ~ f(0, 1))),
+    "Expected rhs of '~' relationship to be a call to a distribution",
+    fixed = TRUE)
+})
+
+
+test_that("collect all dependncies in rhs", {
+  res <- dsl_parse_expr_stochastic(quote(a ~ Normal(a + b * c, a / d)))
+  expect_setequal(res$depends, c("a", "b", "c", "d"))
+  res <- dsl_parse_expr_stochastic(quote(a ~ Normal(f(a), g(10))))
+  expect_equal(res$depends, "a")
+  res <- dsl_parse_expr_stochastic(quote(a ~ Normal(0, 1)))
+  expect_equal(res$depends, character())
+})
+
+
+test_that("require that assignments assign to a symbol", {
+  expect_error(
+    dsl_parse_expr_assignment(quote(f(a) <- 10)),
+    "Expected lhs of assignment to be a symbol")
+  expect_error(
+    dsl_parse_expr_assignment(quote(1 <- 10)),
+    "Expected lhs of assignment to be a symbol")
+})
+
+
+test_that("every expression is classifiable", {
+  expect_error(
+    dsl_parse_expr(1),
+    "Unhandled expression; expected something involving '~' or '<-'",
+    fixed = TRUE)
+  expect_error(
+    dsl_parse_expr(quote(a == 1)),
+    "Unhandled expression; expected something involving '~' or '<-'",
+    fixed = TRUE)
 })

--- a/tests/testthat/test-dsl-parse.R
+++ b/tests/testthat/test-dsl-parse.R
@@ -1,0 +1,53 @@
+test_that("can throw sensible errors with expression information", {
+  expr <- structure(quote(a + b), line = 10, str = "a+b")
+  msg <- "some error message"
+  err <- expect_error(dsl_parse_error(msg, expr), "some error message")
+  expect_equal(err$mcstate2_expr, expr)
+  expect_match(cli::ansi_strip(conditionMessage(err)),
+               "10| a+b", fixed = TRUE)
+})
+
+
+test_that("can throw sensible errors without expression information", {
+  expr <- quote(a + b)
+  msg <- "some error message"
+  err <- expect_error(dsl_parse_error(msg, expr), "some error message")
+  expect_equal(err$mcstate2_expr, expr)
+  expect_match(cli::ansi_strip(conditionMessage(err)),
+               "a + b", fixed = TRUE)
+})
+
+
+test_that("can parse trivial model", {
+  res <- mcstate_dsl_parse(a ~ Normal(0, 1))
+  expect_equal(res$parameters, "a")
+  expect_length(res$exprs, 1)
+  expect_equal(res$exprs,
+               list(dsl_parse_expr_stochastic(quote(a ~ Normal(0, 1)))))
+})
+
+
+test_that("can parse two-parameter model", {
+  res <- mcstate_dsl_parse({
+    a ~ Normal(0, 1)
+    b ~ Exponential(1)
+  })
+  expect_equal(res$parameters, c("a", "b"))
+  expect_length(res$exprs, 2)
+  expect_equal(res$exprs,
+               list(dsl_parse_expr_stochastic(quote(a ~ Normal(0, 1))),
+                    dsl_parse_expr_stochastic(quote(b ~ Exponential(1)))))
+})
+
+
+test_that("can parse model with expressions", {
+  res <- mcstate_dsl_parse({
+    sd <- sqrt(pi)
+    a ~ Normal(0, sd)
+  })
+  expect_equal(res$parameters, "a")
+  expect_length(res$exprs, 2)
+  expect_equal(res$exprs,
+               list(dsl_parse_expr_assignment(quote(sd <- sqrt(pi))),
+                    dsl_parse_expr_stochastic(quote(a ~ Normal(0, sd)))))
+})


### PR DESCRIPTION
This PR adds support for parsing the basic DSL, with much more validation to come (and of course, generation).

The DSL so far is an ordered sequence of either assignments with `<-` or distributional statements with `~`; this will feel **very** familiar to the arguments to `quap` in Statistical Rethinking, and that is not a cooincidence.

So the priors corresponding to the regression model from Ch4 that we've been pondering:

```r
a ~ Normal(178, 20)
b ~ Normal(0, 1) # LogNormal distribution not actually supported yet
sigma ~ Uniform(0, 1)
```

The user can assign

```r
a_mean <- 178
a <- Normal(a_mean, 20)
```

and expressions can be used as arguments.  Order matters, so we disallow

```r
a ~ Normal(b, 1)
b <- 10
```

(this is in contrast to odin).

The error handling in the above is quite nice but is _much_ nicer if the code comes from a file

```
> mcstate_dsl("model.R")
Error:
! Invalid use of variable 'b'
→ In expression
  2| a ~ Normal(b, 1)

ℹ 'b' is defined later:
  4| b <- 20
Run `rlang::last_trace()` to see where the error occurred.
```
