### PR TITLE
Better handling of distributions + basic density generation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,5 @@
 ^\.github$
 \.*gcov$
 ^_pkgdown\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -65,13 +65,13 @@ match_call <- function(args, candidates) {
   }
   detail <- c("x" = sprintf("Failed to match given arguments: %s", given))
 
-  expected <- vcapply(candidates, function(x) paste(names(x), collapse = ", "))
+  expected <- vcapply(candidates, paste, collapse = ", ")
   if (length(candidates) == 1) {
     hint <- c("i" = "Call should match:")
   } else {
     hint <- c("i" = "Call should match one of:")
   }
-  list(success = FALSE, error = c(detail, hint, set_names(expected, ">")))
+  list(success = FALSE, error = c(detail, hint, set_names(expected, "*")))
 }
 
 
@@ -87,7 +87,7 @@ match_call_candidate <- function(args, candidate) {
   if (anyDuplicated(nms[i])) {
     return(NULL)
   }
-  j <- match(nms[i], names(candidate))
+  j <- match(nms[i], candidate)
   if (anyNA(j)) {
     return(NULL)
   }

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -63,7 +63,7 @@ match_call <- function(args, candidates) {
   } else {
     given <- paste(ifelse(nzchar(args), args, "."), collapse = ", ")
   }
-  detail <- c("x" = "Failed to match given argumnents: {given}")
+  detail <- c("x" = sprintf("Failed to match given arguments: %s", given))
 
   expected <- vcapply(candidates, function(x) paste(names(x), collapse = ", "))
   if (length(candidates) == 1) {

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -1,38 +1,46 @@
-## We will expand this shortly to include sampling, then again once
-## differentiation is supported.
-distribution <- function(name, density) {
+## We will expand this later to support differentiation; that might
+## impact the density calculation depending on how we handle the
+## symbolic differentiation vs the automatic differentiation.
+##
+## We also need the domain from the distributions, but the uniform
+## makes this surprisingly hard because it is either domain [a, b]
+## with constant parameters or it is (-Inf, Inf) otherwise!
+distribution <- function(name, density, sample = NULL) {
   args <- names(formals(density))[-1]
   list(name = name,
        args = args,
-       density = density)
+       density = density,
+       sample = sample)
 }
 
 
 distr_exponential_rate <- distribution(
-  "Exponential",
-  density = function(x, rate) dexp(x, rate, log = TRUE))
+  name = "Exponential",
+  density = function(x, rate) dexp(x, rate, log = TRUE),
+  sample = function(rng, rate) rng$exponential(1, rate))
 
 distr_exponential_mean <- distribution(
-  "Exponential",
-  density = function(x, mean) dexp(x, 1 / mean, log = TRUE))
+  name = "Exponential",
+  density = function(x, mean) dexp(x, 1 / mean, log = TRUE),
+  sample = function(rng, mean) rng$exponential(1, 1 / mean))
 
 distr_normal <- distribution(
-  "Normal",
+  name = "Normal",
   density = function(x, mean, sd) dnorm(x, mean, sd, log = TRUE),
-  sample = function(rng, mean, sd) rng$normal(mean, sd))
+  sample = function(rng, mean, sd) rng$normal(1, mean, sd))
 
-distr_uniform <- list(
-  "Uniform",
-  densitry = function(x, min, max) dunif(x, min, max, log = TRUE),
-  sample = function(rng, min, max) rng$uniform(min, max))
+distr_uniform <- distribution(
+  name = "Uniform",
+  density = function(x, min, max) dunif(x, min, max, log = TRUE),
+  sample = function(rng, min, max) rng$uniform(1, min, max))
 
 dsl_distributions <- local({
   d <- list(
-    distr_exponential_rate, # preferred
-    distr_exponential_mean
+    distr_exponential_rate, # preferred form, listed first
+    distr_exponential_mean,
     distr_normal,
     distr_uniform)
-  split(d, vcapply(d, "[[", "name"))
+  split(d, vapply(d, "[[", "", "name"))
 })
 
 

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -1,0 +1,93 @@
+## We will expand this shortly to include sampling, then again once
+## differentiation is supported.
+distribution <- function(name, density) {
+  args <- names(formals(density))[-1]
+  list(name = name,
+       args = args,
+       density = density)
+}
+
+
+distr_exponential_rate <- distribution(
+  "Exponential",
+  density = function(x, rate) dexp(x, rate, log = TRUE))
+
+distr_exponential_mean <- distribution(
+  "Exponential",
+  density = function(x, mean) dexp(x, 1 / mean, log = TRUE))
+
+distr_normal <- distribution(
+  "Normal",
+  density = function(x, mean, sd) dnorm(x, mean, sd, log = TRUE),
+  sample = function(rng, mean, sd) rng$normal(mean, sd))
+
+distr_uniform <- list(
+  "Uniform",
+  densitry = function(x, min, max) dunif(x, min, max, log = TRUE),
+  sample = function(rng, min, max) rng$uniform(min, max))
+
+dsl_distributions <- local({
+  d <- list(
+    distr_exponential_rate, # preferred
+    distr_exponential_mean
+    distr_normal,
+    distr_uniform)
+  split(d, vcapply(d, "[[", "name"))
+})
+
+
+## Utilities to match calls against lists; this would go in util.R but
+## it's really very geared around what we need for validating and
+## disambiguating calls to distribution function
+match_call <- function(args, candidates) {
+  for (i in seq_along(candidates)) {
+    res <- match_call_candidate(args, candidates[[i]])
+    if (!is.null(res)) {
+      return(list(success = TRUE, index = i, args = res))
+    }
+  }
+
+  ## Everything below here is error handling; we've failed to match
+  ## the call.
+  nms <- names(args)
+  if (is.null(nms)) {
+    given <- paste(rep(".", length(args)), collapse = ", ")
+  } else {
+    given <- paste(ifelse(nzchar(args), args, "."), collapse = ", ")
+  }
+  detail <- c("x" = "Failed to match given argumnents: {given}")
+
+  expected <- vcapply(candidates, function(x) paste(names(x), collapse = ", "))
+  if (length(candidates) == 1) {
+    hint <- c("i" = "Call should match:")
+  } else {
+    hint <- c("i" = "Call should match one of:")
+  }
+  list(success = FALSE, error = c(detail, hint, set_names(expected, ">")))
+}
+
+
+match_call_candidate <- function(args, candidate) {
+  if (length(args) != length(candidate)) {
+    return(NULL)
+  }
+  nms <- names(args)
+  if (is.null(nms)) {
+    return(seq_along(args))
+  }
+  i <- nzchar(nms)
+  if (anyDuplicated(nms[i])) {
+    return(NULL)
+  }
+  j <- match(nms[i], names(candidate))
+  if (anyNA(j)) {
+    return(NULL)
+  }
+  ## This is the same logic as used in R's argument matching, which slots in
+  ## named arguments then assigns the remaining as unnamed arguments.
+  n <- length(args)
+  ret <- integer(n)
+  ret[i] <- j
+  ret[seq_len(n)[!i]] <- seq_len(n)[-j]
+  ret
+}

--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -39,7 +39,9 @@ dsl_generate_density_expr <- function(expr) {
   switch(expr$type,
          assignment = dsl_generate_density_assignment(expr),
          stochastic = dsl_generate_density_stochastic(expr),
-         stop("Bug"))
+         cli::cli_abort(paste(
+           "Unimplemented expression type '{expr$type}';",
+           "this is an mcstate2 bug")))
 }
 
 

--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -1,0 +1,59 @@
+dsl_generate <- function(dat) {
+  density <- dsl_generate_density(dat)
+  mcstate_model(
+    list(parameters = dat$parameters,
+         density = density))
+}
+
+
+dsl_generate_density <- function(dat) {
+  ## Here we'll generate a series of self-contained statements, and
+  ## evaluate these in a generic environment.  This disallows use of
+  ## fancy functions that the user provides, but I think that the dsl
+  ## does not really support that anyway, so that feels reasonable.
+  ##
+  ## We're using .x and .density as special input/output vectors, at
+  ## least for now; I don't really know how sustainable that is but
+  ## stops us needing to use a second layer of indirection (e.g., all
+  ## assignments go into some additional list/env and we need to
+  ## manipulate all the calling environments accordingly).  When we
+  ## start generating C code later this will change anyway as there
+  ## we'll need to do lookups anyway.
+  np <- length(dat$parameters)
+  body <- c(dsl_generate_density_unpack(dat$parameters),
+            call("<-", quote(.density), bquote(numeric(.(np)))),
+            lapply(dat$exprs, dsl_generate_density_expr),
+            if (np == 1) quote(.density) else quote(sum(.density)))
+  as_function(alist(.x = ), body, topenv())
+}
+
+
+dsl_generate_density_unpack <- function(parameters) {
+  lapply(seq_along(parameters), function(i) {
+    call("<-", as.name(parameters[[i]]), bquote(.x[.(i)]))
+  })
+}
+
+
+dsl_generate_density_expr <- function(expr) {
+  switch(expr$type,
+         assignment = dsl_generate_density_expr_assignment,
+         stochastic = dsl_generate_density_expr_stochastic,
+         stop("Bug"))
+}
+
+
+dsl_generate_density_assignment <- function(expr) {
+  expr$expr
+}
+
+
+dsl_generate_density_stochastic <- function(expr) {
+  fn <- switch(expr$distribution,
+               Normal = quote(dnorm),
+               Exponential = quote(dexp),
+               Uniform = quote(dunif))
+  lhs <- bquote(.density[[.(expr$name)]])
+  rhs <- as.call(c(list(fn, as.name(expr$name)), expr$args, list(log = TRUE)))
+  call("<-", lhs, rhs)
+}

--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -59,12 +59,13 @@ dsl_parse_expr_stochastic <- function(expr) {
   }
 
   ## Next, match the arguments to the call, in order to
+  distr_name <- as.character(rhs[[1]])
   args <- as.list(rhs[-1])
   candidates <- dsl_distributions[[distr_name]]
   match <- match_call(args, lapply(candidates, "[[", "args"))
   if (!match$success) {
     dsl_parse_error(
-      c("Invalid call to '{name()}'", match$error),
+      c("Invalid call to '{distr_name}()'", match$error),
       expr)
   }
 
@@ -77,7 +78,7 @@ dsl_parse_expr_stochastic <- function(expr) {
   ## Here we might check the arguments to the distribution functions,
   ## too, but that's also easy enough to do elsewhere.
   list(type = "stochastic",
-       name = lhs,
+       name = as.character(lhs),
        distribution = candidates[[match$index]],
        args = args[match$args],
        depends = depends,

--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -33,16 +33,38 @@ dsl_parse_expr_stochastic <- function(expr) {
   }
   rhs <- expr[[3]]
 
-  ## TODO: this will be derived from source of truth soon; we'll need
-  ## to also provide information about what distributions are
-  ## supported too; I'll do that on the next PR as it will be a bit
-  ## complicated most likely and start intersecting with what
-  ## distributions we aim to support. At that point we'll do a better
-  ## error.
-  supported <- c("Normal", "Exponential", "Uniform")
-  if (!rlang::is_call(rhs, supported)) {
+  ## Here, the user has not provided a call to anything, or a call to
+  ## something that is not recognised as a distribution.  We throw the
+  ## same error in both cases, but with different contextual
+  ## information in order to fix the error.
+  if (!rlang::is_call(rhs, names(dsl_distributions))) {
+    if (!rlang::is_call(rhs)) {
+      detail <- c("x" = "rhs is not a function call")
+    } else {
+      detail <- c(i = paste("See ?'dsl-distributions' for details on",
+                            "supported distributions"))
+      distr_name <- as.character(rhs[[1]])
+      dym <- near_match(distr_name, names(dsl_distributions))
+      if (length(dym) > 0) {
+        detail <- c(
+          "i" = paste("Unknown distribution '{distr_name}', did you mean:",
+                      "{squote(dym)}"),
+          detail)
+      }
+    }
     dsl_parse_error(
-      "Expected rhs of '~' relationship to be a call to a distribution",
+      c("Expected rhs of '~' relationship to be a call to a distribution",
+        detail),
+      expr)
+  }
+
+  ## Next, match the arguments to the call, in order to
+  args <- as.list(rhs[-1])
+  candidates <- dsl_distributions[[distr_name]]
+  match <- match_call(args, lapply(candidates, "[[", "args"))
+  if (!match$success) {
+    dsl_parse_error(
+      c("Invalid call to '{name()}'", match$error),
       expr)
   }
 
@@ -55,9 +77,9 @@ dsl_parse_expr_stochastic <- function(expr) {
   ## Here we might check the arguments to the distribution functions,
   ## too, but that's also easy enough to do elsewhere.
   list(type = "stochastic",
-       name = as.character(lhs),
-       distribution = as.character(rhs[[1]]),
-       args = as.list(rhs[-1]),
+       name = lhs,
+       distribution = candidates[[match$index]],
+       args = args[match$args],
        depends = depends,
        expr = expr)
 }

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -40,7 +40,7 @@ mcstate_dsl <- function(x, type = NULL) {
   }
   exprs <- dsl_preprocess(x, type)
   dat <- dsl_parse(exprs)
-  NULL
+  dsl_generate(dat)
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -113,9 +113,6 @@ as_function <- function(args, body, envir) {
 
 
 near_match <- function(x, possibilities, threshold = 2, max_matches = 5) {
-  if (length(possibilities) == 0) {
-    return(character())
-  }
   i <- tolower(x) == tolower(possibilities)
   if (any(i)) {
     possibilities[i]

--- a/R/util.R
+++ b/R/util.R
@@ -102,3 +102,26 @@ all_same <- function(x) {
   }
   all(vlapply(x[-1], identical, x[[1]]))
 }
+
+
+as_function <- function(args, body, envir) {
+  if (!rlang::is_call(body, "{")) {
+    body <- rlang::call2("{", !!!body)
+  }
+  as.function(c(args, alist(body)), envir = envir)
+}
+
+
+near_match <- function(x, possibilities, threshold = 2, max_matches = 5) {
+  if (length(possibilities) == 0) {
+    return(character())
+  }
+  i <- tolower(x) == tolower(possibilities)
+  if (any(i)) {
+    possibilities[i]
+  } else {
+    d <- set_names(drop(utils::adist(x, possibilities, ignore.case = TRUE)),
+                   possibilities)
+    utils::head(names(sort(d[d <= threshold])), max_matches)
+  }
+}

--- a/R/util.R
+++ b/R/util.R
@@ -108,7 +108,7 @@ as_function <- function(args, body, envir) {
   if (!rlang::is_call(body, "{")) {
     body <- rlang::call2("{", !!!body)
   }
-  as.function(c(args, alist(body)), envir = envir)
+  as.function(c(args, body), envir = envir)
 }
 
 

--- a/mcstate2.Rproj
+++ b/mcstate2.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-dsl-distributions.R
+++ b/tests/testthat/test-dsl-distributions.R
@@ -18,7 +18,7 @@ test_that("match against set of candidates", {
   expect_equal(match_call(list(0, b = 0), candidates),
                list(success = TRUE, index = 1, args = 1:2))
   expect_equal(match_call(list(a = 0, b = 0), candidates),
-               list(success = TRUE, index = 1, args = 1:2))?
+               list(success = TRUE, index = 1, args = 1:2))
   expect_equal(match_call(list(b = 0, a = 0), candidates),
                list(success = TRUE, index = 1, args = 2:1))
   expect_equal(match_call(list(0, scale = 0), candidates),
@@ -29,12 +29,12 @@ test_that("match against set of candidates", {
   error <- c(x = "Failed to match given arguments: .",
              i = "Call should match one of:",
              ">" = "a, b",
-             ">" = "scale, shape")
+             ">" = "shape, scale")
   expect_equal(
     match_call(list(0), candidates),
     list(success = FALSE, error = error))
 
-  error <- c(x = "Failed to match given arguments: .",
+  error <- c(x = "Failed to match given arguments: 1, 2, 3",
              i = "Call should match:",
              ">" = "a, b")
   expect_equal(
@@ -46,7 +46,7 @@ test_that("match against set of candidates", {
 ## These are all very poor tests in that they just restate the
 ## implementation.  I am not really clear how we can do better than
 ## this at the moment.  That said, there's a chance we'll swap out the
-## implemnentation later for something symbolically differentiable so
+## implementation later for something symbolically differentiable so
 ## at that point these would become fairly useful.
 test_that("can compute density for exponential distribution", {
   expect_equal(distr_exponential_rate$density(3.1, 0.4),
@@ -55,13 +55,40 @@ test_that("can compute density for exponential distribution", {
                dexp(3.1, 1 / 0.4, log = TRUE))
 })
 
+
+test_that("can sample from exponential distribution", {
+  r1 <- mcstate_rng$new(1)
+  r2 <- mcstate_rng$new(1)
+  expect_equal(distr_exponential_rate$sample(r1, 0.4),
+               r2$exponential(1, 0.4))
+  expect_equal(distr_exponential_mean$sample(r1, 0.4),
+               r2$exponential(1, 1 / 0.4))
+})
+
+
 test_that("can compute density for normal distribution", {
-  expect_equal(distr_normal_rate$density(0, 1, 2),
-               dnorm(0, 1, 2, log = TRUE)
+  expect_equal(distr_normal$density(0, 1, 2),
+               dnorm(0, 1, 2, log = TRUE))
+})
+
+
+test_that("can sample from normal distribution", {
+  r1 <- mcstate_rng$new(1)
+  r2 <- mcstate_rng$new(1)
+  expect_equal(distr_normal$sample(r1, 1, 2),
+               r2$normal(1, 1, 2))
 })
 
 
 test_that("can compute density for uniform distribution", {
-  expect_equal(distr_normal_rate$uniform(1, 2, 3),
+  expect_equal(distr_uniform$density(1, 2, 3),
                dunif(1, 2, 3, log = TRUE))
+})
+
+
+test_that("can sample from uniform distribution", {
+  r1 <- mcstate_rng$new(1)
+  r2 <- mcstate_rng$new(1)
+  expect_equal(distr_uniform$sample(r1, 2, 3),
+               r2$uniform(1, 2, 3))
 })

--- a/tests/testthat/test-dsl-distributions.R
+++ b/tests/testthat/test-dsl-distributions.R
@@ -1,0 +1,67 @@
+test_that("check argument matching", {
+  candidate <- alist(mean = , sd = )
+  expect_equal(match_call_candidate(list("a", "b"), candidate), 1:2)
+  expect_null(match_call_candidate(list("a", "b", "c"), candidate))
+  expect_equal(match_call_candidate(list("a", sd = "b"), candidate), 1:2)
+  expect_equal(match_call_candidate(list(mean = "a", sd = "b"), candidate), 1:2)
+  expect_null(match_call_candidate(list(sd = "a", sd = "b"), candidate), 1:2)
+  expect_null(match_call_candidate(list(mu = "a", sd = "b"), candidate), 1:2)
+  expect_equal(match_call_candidate(list(sd = "a", mean = "b"), candidate), 2:1)
+})
+
+
+test_that("match against set of candidates", {
+  candidates <- list(alist(a = , b = ),
+                     alist(shape = , scale = ))
+  expect_equal(match_call(list(0, 0), candidates),
+               list(success = TRUE, index = 1, args = 1:2))
+  expect_equal(match_call(list(0, b = 0), candidates),
+               list(success = TRUE, index = 1, args = 1:2))
+  expect_equal(match_call(list(a = 0, b = 0), candidates),
+               list(success = TRUE, index = 1, args = 1:2))?
+  expect_equal(match_call(list(b = 0, a = 0), candidates),
+               list(success = TRUE, index = 1, args = 2:1))
+  expect_equal(match_call(list(0, scale = 0), candidates),
+               list(success = TRUE, index = 2, args = 1:2))
+  expect_equal(match_call(list(scale = 0, shape = 0), candidates),
+               list(success = TRUE, index = 2, args = 2:1))
+
+  error <- c(x = "Failed to match given arguments: .",
+             i = "Call should match one of:",
+             ">" = "a, b",
+             ">" = "scale, shape")
+  expect_equal(
+    match_call(list(0), candidates),
+    list(success = FALSE, error = error))
+
+  error <- c(x = "Failed to match given arguments: .",
+             i = "Call should match:",
+             ">" = "a, b")
+  expect_equal(
+    match_call(list(a = 1, b = 2, c = 3), candidates[1]),
+    list(success = FALSE, error = error))
+})
+
+
+## These are all very poor tests in that they just restate the
+## implementation.  I am not really clear how we can do better than
+## this at the moment.  That said, there's a chance we'll swap out the
+## implemnentation later for something symbolically differentiable so
+## at that point these would become fairly useful.
+test_that("can compute density for exponential distribution", {
+  expect_equal(distr_exponential_rate$density(3.1, 0.4),
+               dexp(3.1, 0.4, log = TRUE))
+  expect_equal(distr_exponential_mean$density(3.1, 0.4),
+               dexp(3.1, 1 / 0.4, log = TRUE))
+})
+
+test_that("can compute density for normal distribution", {
+  expect_equal(distr_normal_rate$density(0, 1, 2),
+               dnorm(0, 1, 2, log = TRUE)
+})
+
+
+test_that("can compute density for uniform distribution", {
+  expect_equal(distr_normal_rate$uniform(1, 2, 3),
+               dunif(1, 2, 3, log = TRUE))
+})

--- a/tests/testthat/test-dsl-distributions.R
+++ b/tests/testthat/test-dsl-distributions.R
@@ -1,5 +1,5 @@
 test_that("check argument matching", {
-  candidate <- alist(mean = , sd = )
+  candidate <- c("mean", "sd")
   expect_equal(match_call_candidate(list("a", "b"), candidate), 1:2)
   expect_null(match_call_candidate(list("a", "b", "c"), candidate))
   expect_equal(match_call_candidate(list("a", sd = "b"), candidate), 1:2)
@@ -11,8 +11,7 @@ test_that("check argument matching", {
 
 
 test_that("match against set of candidates", {
-  candidates <- list(alist(a = , b = ),
-                     alist(shape = , scale = ))
+  candidates <- list(c("a", "b"), c("shape", "scale"))
   expect_equal(match_call(list(0, 0), candidates),
                list(success = TRUE, index = 1, args = 1:2))
   expect_equal(match_call(list(0, b = 0), candidates),
@@ -28,15 +27,15 @@ test_that("match against set of candidates", {
 
   error <- c(x = "Failed to match given arguments: .",
              i = "Call should match one of:",
-             ">" = "a, b",
-             ">" = "shape, scale")
+             "*" = "a, b",
+             "*" = "shape, scale")
   expect_equal(
     match_call(list(0), candidates),
     list(success = FALSE, error = error))
 
   error <- c(x = "Failed to match given arguments: 1, 2, 3",
              i = "Call should match:",
-             ">" = "a, b")
+             "*" = "a, b")
   expect_equal(
     match_call(list(a = 1, b = 2, c = 3), candidates[1]),
     list(success = FALSE, error = error))
@@ -91,4 +90,16 @@ test_that("can sample from uniform distribution", {
   r2 <- mcstate_rng$new(1)
   expect_equal(distr_uniform$sample(r1, 2, 3),
                r2$uniform(1, 2, 3))
+})
+
+
+## Needs special testing because the primary use is currently during
+## package build
+test_that("can create a distribution object", {
+  density <- function(x, a, b) NULL
+  sample <- function(rng, a, b) NULL
+  d <- distribution("Foo", density, sample)
+  expect_equal(
+    d,
+    list(name = "Foo", args = c("a", "b"), density = density, sample = sample))
 })

--- a/tests/testthat/test-dsl-generate.R
+++ b/tests/testthat/test-dsl-generate.R
@@ -1,0 +1,5 @@
+test_that("throw useful error if we have new unimplemented expression types", {
+  expect_error(
+    dsl_generate_density_expr(list(type = "magic")),
+    "Unimplemented expression type 'magic'; this is an mcstate2 bug")
+})

--- a/tests/testthat/test-dsl-parse.R
+++ b/tests/testthat/test-dsl-parse.R
@@ -162,3 +162,39 @@ test_that("Can run high level dsl parse function", {
   x <- "a ~ Normal(0, 1)"
   expect_equal(mcstate_dsl_parse(x), res)
 })
+
+
+test_that("require that rhs to stochastic statement is a call", {
+  err <- expect_error(
+    mcstate_dsl_parse(a ~ 1),
+    "Expected rhs of '~' relationship to be a call to a distribution")
+  expect_equal(err$body[[1]], "rhs is not a function call")
+})
+
+
+test_that("require that rhs to stochastic statement is known distribution", {
+  err <- expect_error(
+    mcstate_dsl_parse(a ~ normal(0, 1)),
+    "Expected rhs of '~' relationship to be a call to a distribution")
+  expect_equal(err$body[[1]],
+               "Unknown distribution 'normal', did you mean: 'Normal'")
+})
+
+test_that("sensisible error if no suggestions for distribution found", {
+  err <- expect_error(
+    mcstate_dsl_parse(a ~ QQQ(0, 1)),
+    "Expected rhs of '~' relationship to be a call to a distribution")
+  expect_no_match(conditionMessage(err), "did you mean")
+})
+
+
+test_that("report back invalid distribution calls", {
+  err <- expect_error(
+    mcstate_dsl_parse(a ~ Normal(0, 1, 2)),
+    "Invalid call to 'Normal()'", fixed = TRUE)
+  expect_equal(
+    err$body,
+    c("x" = "Failed to match given arguments: ., ., .",
+      "i" = "Call should match:",
+      "*" = "mean, sd"))
+})

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -1,7 +1,8 @@
 test_that("Can run high level dsl function", {
-  expect_null(mcstate_dsl("a ~ Normal(0, 1)"))
-  expect_null(mcstate_dsl(a ~ Normal(0, 1)))
-  x <- quote(a ~ Normal(0, 1))
-  expect_null(mcstate_dsl(x))
-  expect_error(mcstate_dsl(y))
+  m <- mcstate_dsl("a ~ Normal(0, 1)")
+  expect_s3_class(m, "mcstate_model")
+  expect_equal(m$density(0), dnorm(0, 0, 1, log = TRUE))
+  ## x <- quote(a ~ Normal(0, 1))
+  ## expect_null(mcstate_dsl(x))
+  ## expect_error(mcstate_dsl(y))
 })

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -2,7 +2,15 @@ test_that("Can run high level dsl function", {
   m <- mcstate_dsl("a ~ Normal(0, 1)")
   expect_s3_class(m, "mcstate_model")
   expect_equal(m$density(0), dnorm(0, 0, 1, log = TRUE))
-  ## x <- quote(a ~ Normal(0, 1))
-  ## expect_null(mcstate_dsl(x))
-  ## expect_error(mcstate_dsl(y))
+})
+
+
+test_that("can generate model with simple assignement", {
+  x <- quote({
+    mu <- 5
+    a ~ Normal(mu, 1)
+  })
+  m <- mcstate_dsl(x)
+  expect_s3_class(m, "mcstate_model")
+  expect_equal(m$density(0), dnorm(0, 5, 1, log = TRUE))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -57,3 +57,17 @@ test_that("can test if things are the same", {
   expect_true(all_same(rep(1, 10)))
   expect_false(all_same(c(1, 1, 2, 1)))
 })
+
+
+test_that("can get near matches", {
+  x <- c("apples", "applez", "appell", "applly")
+  expect_equal(
+    near_match("apple", x),
+    c("apples", "applez", "appell", "applly"))
+  expect_equal(
+    near_match("apple", x, 1),
+    c("apples", "applez"))
+  expect_equal(
+    near_match("apple", x, 2, 3),
+    c("apples", "applez", "appell"))
+})


### PR DESCRIPTION
This PR implements two features that can be separated, but were developed together.  If you would prefer to review them separately I can easily chop them back apart.

First, we add support for some basic distribution objects (e.g., the Exponential distribution or the Normal distribution).  This is mostly just a list with parameters of the distributions and density/sampling functions.  There are two wrinkles here though:

* the domain is not trivial, because for Uniform the practical domain is [`min`, `max`] and not (`-Inf`, `Inf`).  This means that we need the parameters before we can compute the range and that's going to require some thought.  So for now we don't know the domains, which will restrict use with HMC but that's fine as we also don't support differentiation!
* some distributions have multiple parameterisations.  The one that we care about is the negative binomial, which is not implemented here yet.  To keep the PR small I've only used the same three distributions used in the previous version of code - Normal/Exponential/Uniform and so have written this to support the two commonly seen form of Exponential; in terms of rate and in terms of mean.  When we see a call to a distribution (e.g., `Normal(0, 1)` or `Exponential(1)`) we will match the different forms of the distribution with named and positional arguments to try and work out what the user wants.  So `a ~ Exponential(mean = 10)` will select the "mean" form of the exponential distribution while `a ~ Exponential(0.1)` and `a ~ Exponential(rate = 0.1)` select the equivalent distribution parameterised using rate.  Doing this requires some gymnastics with argument matching in dsl-distributions.R

The code generation after this is quite unremarkable I think; note that I have done the density only and not the sampling, though that follows pretty much directly