### PR TITLE
More flexible domain

### DIFF
--- a/man/mcstate_model.Rd
+++ b/man/mcstate_model.Rd
@@ -61,9 +61,14 @@ as the first and second column.  Infinite values (\code{-Inf} or
 \code{Inf}) should be used where the parameter has infinite domain up
 or down.  Currently used to translate from a bounded to
 unbounded space for HMC, but we might also use this for
-reflecting proposals in MCMC too.  If not present we assume that
-the model is valid everywhere (i.e., that all parameters are
-valid from \code{-Inf} to \code{Inf}.
+reflecting proposals in MCMC too, as well as a fast way of
+avoiding calculating densities where proposals fall out of
+bounds.  If not present we assume that the model is valid
+everywhere (i.e., that all parameters are valid from \code{-Inf} to
+\code{Inf}.  If unnamed, you must provide a domain for all
+parameters.  If named, then you can provide a subset, with
+parameters that are not included assumed to have a domain of
+\verb{(-Inf, Inf)}.
 \item \code{direct_sample}: A function to sample directly from the
 parameter space, given an \link{mcstate_rng} object to sample from.
 In the case where a model returns a posterior (e.g., in Bayesian

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -86,10 +86,26 @@ test_that("validate domain", {
     mcstate_model(list(density = identity,
                        parameters = "a",
                        domain = rbind(A = c(0, 1)))),
-    "Unexpected rownames on domain",
+    "Unexpected parameters found in 'model$domain' rownames",
     fixed = TRUE)
 })
 
+
+test_that("fill in default domain entries where only some provided", {
+  base <- list(density = sum, parameters = letters[1:3])
+  default <- matrix(c(-Inf, Inf), 3, 2, byrow = TRUE,
+                    dimnames = list(letters[1:3], NULL))
+  expect_equal(
+    mcstate_model(modifyList(base, list(domain = NULL)))$domain,
+    default)
+  expect_equal(
+    mcstate_model(modifyList(base, list(domain = rbind(b = c(0, 1)))))$domain,
+    rbind(a = c(-Inf, Inf), b = c(0, 1), c = c(-Inf, Inf)))
+  change <- rbind(b = c(0, 1), a = c(-1, 2))
+  expect_equal(
+    mcstate_model(modifyList(base, list(domain = change)))$domain,
+    rbind(a = c(-1, 2), b = c(0, 1), c = c(-Inf, Inf)))
+})
 
 test_that("can use properties to guarantee that a property exists", {
   m <- list(density = function(x) dnorm(x, log = TRUE), parameters = "a")


### PR DESCRIPTION
Less explicit way of specifying the domain.  With this, the user can provide explicit parameter domains for a subset of model parameters and the remainder are assumed to be valid over `(-Inf, Inf)`