### PR TITLE
Generate sample functions from dsl

### DIFF
--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -77,7 +77,8 @@ dsl_generate_density_stochastic <- function(expr, env, density) {
 
 dsl_generate_sample_stochastic <- function(expr, env) {
   lhs <- bquote(.(env)[[.(expr$name)]])
-  args <- lapply(expr$args, dsl_generate_density_rewrite_lookup, env)
+  args <- lapply(expr$distribution$args, dsl_generate_density_rewrite_lookup,
+                 env)
   rhs <- rlang::call2(expr$distribution$sample, quote(rng), !!!args)
   rlang::call2("<-", lhs, rhs)
 }

--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -1,30 +1,34 @@
 dsl_generate <- function(dat) {
-  density <- dsl_generate_density(dat)
+  env <- new.env(parent = asNamespace("mcstate"))
+  env$packer <- mcstate_packer(dat$parameters)
+
+  density <- dsl_generate_density(dat, env)
+  direct_sample <- dsl_generate_direct_sample(dat, env)
   mcstate_model(
     list(parameters = dat$parameters,
-         density = density))
+         density = density,
+         direct_sample = direct_sample))
 }
 
 
-dsl_generate_density <- function(dat) {
-  ## Here we'll generate a series of self-contained statements, and
-  ## evaluate these in a generic environment.  This disallows use of
-  ## fancy functions that the user provides, but I think that the dsl
-  ## does not really support that anyway, so that feels reasonable.
-  ##
-  ## We're using .x and .density as special input/output vectors, at
-  ## least for now; I don't really know how sustainable that is but
-  ## stops us needing to use a second layer of indirection (e.g., all
-  ## assignments go into some additional list/env and we need to
-  ## manipulate all the calling environments accordingly).  When we
-  ## start generating C code later this will change anyway as there
-  ## we'll need to do lookups anyway.
-  np <- length(dat$parameters)
-  body <- c(dsl_generate_density_unpack(dat$parameters),
-            quote(.density <- numeric()),
-            lapply(dat$exprs, dsl_generate_density_expr),
-            quote(sum(.density)))
-  as_function(alist(.x = ), body, topenv())
+dsl_generate_density <- function(dat, env) {
+  exprs <- lapply(dat$exprs, dsl_generate_density_expr,
+                  quote(pars), quote(density))
+  body <- c(quote(pars <- packer$unpack(x)),
+            quote(density <- numeric()),
+            exprs,
+            quote(sum(density)))
+  as_function(alist(x = ), body, env)
+}
+
+
+dsl_generate_direct_sample <- function(dat, env) {
+  exprs <- lapply(dat$exprs, dsl_generate_sample_expr,
+                  quote(pars), quote(result))
+  body <- c(quote(pars <- list()),
+            exprs,
+            quote(unlist(pars[packer$parameters], FALSE, FALSE)))
+  as_function(alist(rng = ), body, env)
 }
 
 
@@ -35,24 +39,57 @@ dsl_generate_density_unpack <- function(parameters) {
 }
 
 
-dsl_generate_density_expr <- function(expr) {
+dsl_generate_density_expr <- function(expr, env, density) {
   switch(expr$type,
-         assignment = dsl_generate_density_assignment(expr),
-         stochastic = dsl_generate_density_stochastic(expr),
+         assignment = dsl_generate_assignment(expr, env),
+         stochastic = dsl_generate_density_stochastic(expr, env, density),
          cli::cli_abort(paste(
            "Unimplemented expression type '{expr$type}';",
            "this is an mcstate2 bug")))
 }
 
 
-dsl_generate_density_assignment <- function(expr) {
-  expr$expr
+dsl_generate_sample_expr <- function(expr, env, result) {
+  switch(expr$type,
+         assignment = dsl_generate_assignment(expr, env),
+         stochastic = dsl_generate_sample_stochastic(expr, env),
+         cli::cli_abort(paste(
+           "Unimplemented expression type '{expr$type}';",
+           "this is an mcstate2 bug")))
 }
 
 
-dsl_generate_density_stochastic <- function(expr) {
-  lhs <- bquote(.density[[.(expr$name)]])
+dsl_generate_assignment <- function(expr, env) {
+  e <- expr$expr
+  e[[2]] <- call("$", quote(pars), e[[2]])
+  e[[3]] <- dsl_generate_density_rewrite_lookup(e[[3]], env)
+  e
+}
+
+
+dsl_generate_density_stochastic <- function(expr, env, density) {
+  lhs <- bquote(.(density)[[.(expr$name)]])
   rhs <- rlang::call2(expr$distribution$density,
                       as.name(expr$name), !!!expr$distribution$args)
+  rlang::call2("<-", lhs, dsl_generate_density_rewrite_lookup(rhs, env))
+}
+
+
+dsl_generate_sample_stochastic <- function(expr, env) {
+  lhs <- bquote(.(env)[[.(expr$name)]])
+  args <- lapply(expr$args, dsl_generate_density_rewrite_lookup, env)
+  rhs <- rlang::call2(expr$distribution$sample, quote(rng), !!!args)
   rlang::call2("<-", lhs, rhs)
+}
+
+
+dsl_generate_density_rewrite_lookup <- function(expr, env) {
+  if (is.recursive(expr)) {
+    expr[-1] <- lapply(expr[-1], dsl_generate_density_rewrite_lookup, env)
+    as.call(expr)
+  } else if (is.name(expr)) {
+    call("[[", env, as.character(expr))
+  } else {
+    expr
+  }
 }

--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -1,5 +1,5 @@
 dsl_generate <- function(dat) {
-  env <- new.env(parent = asNamespace("mcstate"))
+  env <- new.env(parent = asNamespace("mcstate2"))
   env$packer <- mcstate_packer(dat$parameters)
 
   density <- dsl_generate_density(dat, env)

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -14,3 +14,29 @@ test_that("can generate model with simple assignment", {
   expect_s3_class(m, "mcstate_model")
   expect_equal(m$density(0), dnorm(0, 5, 1, log = TRUE))
 })
+
+
+test_that("can sample from a simple model", {
+  m <- mcstate_dsl("a ~ Normal(0, 1)")
+  expect_s3_class(m, "mcstate_model")
+  expect_true(m$properties$has_direct_sample)
+
+  r <- mcstate_rng$new(seed = 42)
+  cmp <- r$normal(1, 0, 1)
+
+  r <- mcstate_rng$new(seed = 42)
+  expect_equal(m$direct_sample(r), cmp)
+})
+
+
+test_that("can sample from a model with assignments", {
+  m <- mcstate_dsl({
+    mu <- 5
+    a ~ Normal(mu, 1)
+  })
+  r <- mcstate_rng$new(seed = 42)
+  cmp <- r$normal(1, 5, 1)
+
+  r <- mcstate_rng$new(seed = 42)
+  expect_equal(m$direct_sample(r), cmp)
+})


### PR DESCRIPTION
So, I thought I'd done more of this but it turns out that I have not done so.

This PR generates `direct_sample` capability for a model, following the same logic as used to generate the density; that is, we work down the statements and evaluate expressions in turn.  The difference is that when computing density when we hit:

```
a ~ Normal(0, 1)
```

we'd save into our final density the result of the density of `density(Normal(a, 0, 1))`, here we need to save into a parameter vector a draw from `Normal(0, 1)`.

To make this easier to implement I've made some changes to the code generation:

* we now use parameter unpacking via the packer; we then work in the "scope" created by that list.  This means we unpack into a list and any assignments would assign into that same list, removing the use of `.x` and the evaluating environment of the function.
* we save the density into a vector as before, but we can just call this `density`
* we do a similar thing with the sample, where we sample into the `env` list and subset out later
* I've written the functions that do the work so that they don't need to know the name of the values used above in the context of the function, even though they are generating code that uses that name
