### PR TITLE
Expand distribution support

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -64,6 +64,10 @@ mcstate_rng_cauchy <- function(ptr, n, r_location, r_scale, n_threads, is_float)
   .Call(`_mcstate2_mcstate_rng_cauchy`, ptr, n, r_location, r_scale, n_threads, is_float)
 }
 
+mcstate_rng_beta <- function(ptr, n, r_a, r_b, n_threads, is_float) {
+  .Call(`_mcstate2_mcstate_rng_beta`, ptr, n, r_a, r_b, n_threads, is_float)
+}
+
 mcstate_rng_multinomial <- function(ptr, n, r_size, r_prob, n_threads, is_float) {
   .Call(`_mcstate2_mcstate_rng_multinomial`, ptr, n, r_size, r_prob, n_threads, is_float)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -24,8 +24,12 @@ mcstate_rng_uniform <- function(ptr, n, r_min, r_max, n_threads, is_float) {
   .Call(`_mcstate2_mcstate_rng_uniform`, ptr, n, r_min, r_max, n_threads, is_float)
 }
 
-mcstate_rng_exponential <- function(ptr, n, r_rate, n_threads, is_float) {
-  .Call(`_mcstate2_mcstate_rng_exponential`, ptr, n, r_rate, n_threads, is_float)
+mcstate_rng_exponential_rate <- function(ptr, n, r_rate, n_threads, is_float) {
+  .Call(`_mcstate2_mcstate_rng_exponential_rate`, ptr, n, r_rate, n_threads, is_float)
+}
+
+mcstate_rng_exponential_mean <- function(ptr, n, r_mean, n_threads, is_float) {
+  .Call(`_mcstate2_mcstate_rng_exponential_mean`, ptr, n, r_mean, n_threads, is_float)
 }
 
 mcstate_rng_normal <- function(ptr, n, r_mean, r_sd, n_threads, algorithm, is_float) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -48,8 +48,12 @@ mcstate_rng_hypergeometric <- function(ptr, n, r_n1, r_n2, r_k, n_threads, is_fl
   .Call(`_mcstate2_mcstate_rng_hypergeometric`, ptr, n, r_n1, r_n2, r_k, n_threads, is_float)
 }
 
-mcstate_rng_gamma <- function(ptr, n, r_a, r_b, n_threads, is_float) {
-  .Call(`_mcstate2_mcstate_rng_gamma`, ptr, n, r_a, r_b, n_threads, is_float)
+mcstate_rng_gamma_scale <- function(ptr, n, r_shape, r_scale, n_threads, is_float) {
+  .Call(`_mcstate2_mcstate_rng_gamma_scale`, ptr, n, r_shape, r_scale, n_threads, is_float)
+}
+
+mcstate_rng_gamma_rate <- function(ptr, n, r_shape, r_rate, n_threads, is_float) {
+  .Call(`_mcstate2_mcstate_rng_gamma_rate`, ptr, n, r_shape, r_rate, n_threads, is_float)
 }
 
 mcstate_rng_poisson <- function(ptr, n, r_lambda, n_threads, is_float) {

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -166,6 +166,18 @@ derivative <- list(
     a <- maths$rewrite(expr[[2]])
     maths$times(differentiate(a, name), call("sign", a))
   },
+  lbeta = function(expr, name) {
+    ## Consider lbeta(a, b) as lgamma(a) + lgamma(b) - lgamma(a + b)
+    ##
+    ## We rewrite the expression into this form and then differentiate
+    ## it:
+    a <- maths$rewrite(expr[[2]])
+    b <- maths$rewrite(expr[[3]])
+    expr2 <- maths$minus(
+      maths$plus(call("lgamma", a), call("lgamma", b)),
+      call("lgamma", maths$plus(a, b)))
+    differentiate(expr2, name)
+  },
   lgamma = function(expr, name) {
     a <- maths$rewrite(expr[[2]])
     maths$times(differentiate(a, name), call("digamma", a))

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -54,7 +54,7 @@ distr_binomial <- distribution(
     density = quote(lchoose(size, x) + x * log(prob) +
                     (size - x) * log(1 - prob)),
     mean = quote(size * prob)),
-  cpp = list(density = NULL, sample = "binomial"))
+  cpp = list(density = "binomial", sample = "binomial"))
 
 distr_exponential_rate <- distribution(
   name = "Exponential",
@@ -83,7 +83,7 @@ distr_gamma_rate <- distribution(
   variant = "rate",
   density = function(x, shape, rate) dgamma(x, shape, rate = rate, log = TRUE),
   domain = c(0, Inf),
-  sample = function(rng, shape, rate) rng$gamma(1, shape, 1 / rate),
+  sample = function(rng, shape, rate) rng$gamma_rate(1, shape, rate),
   expr = list(
     density = quote((shape - 1) * log(x) - rate * x -
                     lgamma(shape) + shape * log(rate)),
@@ -97,7 +97,7 @@ distr_gamma_scale <- distribution(
     dgamma(x, shape, scale = scale, log = TRUE)
   },
   domain = c(0, Inf),
-  sample = function(rng, shape, scale) rng$gamma(1, shape, scale),
+  sample = function(rng, shape, scale) rng$gamma_scale(1, shape, scale),
   expr = list(
     density = quote((shape - 1) * log(x) - x / scale -
                     lgamma(shape) - shape * log(scale)),

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -44,6 +44,15 @@ distribution <- function(name, density, domain, cpp, expr,
        cpp = cpp)
 }
 
+distr_beta <- distribution(
+  name = "Beta",
+  density = function(x, a, b) dbeta(x, a, b, log = TRUE),
+  domain = c(0, 1),
+  sample = function(rng, a, b) rng$beta(1, a, b),
+  expr = list(
+    density = quote((a - 1) * log(x) + (b - 1) * log(1 - x) - lbeta(a, b)),
+    mean = quote(a / (a + b))),
+  cpp = list(density = "beta", sample = "beta"))
 
 distr_binomial <- distribution(
   name = "Binomial",
@@ -148,11 +157,13 @@ distr_uniform <- distribution(
 
 dsl_distributions <- local({
   d <- list(
+    distr_beta,
     distr_binomial,
     distr_exponential_rate, # preferred form, listed first
     distr_exponential_mean,
     distr_gamma_rate,
     distr_gamma_scale,
+    distr_hypergeometric,
     distr_normal,
     distr_poisson,
     distr_uniform)

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -61,22 +61,22 @@ distr_exponential_rate <- distribution(
   variant = "rate",
   density = function(x, rate) dexp(x, rate, log = TRUE),
   domain = c(0, Inf),
-  sample = function(rng, rate) rng$exponential(1, rate),
+  sample = function(rng, rate) rng$exponential_rate(1, rate),
   expr = list(
     density = quote(log(rate) - rate * x),
     mean = quote(1 / rate)),
-  cpp = list(density = NULL, sample = "exponential"))
+  cpp = list(density = "exponential_rate", sample = "exponential_rate"))
 
 distr_exponential_mean <- distribution(
   name = "Exponential",
   variant = "mean",
   density = function(x, mean) dexp(x, 1 / mean, log = TRUE),
   domain = c(0, Inf),
-  sample = function(rng, mean) rng$exponential(1, 1 / mean),
+  sample = function(rng, mean) rng$exponential_mean(1, mean),
   expr = list(
     density = quote(-log(mean) - x / mean),
     mean = quote(mean)),
-  cpp = list(density = NULL, sample = NULL))
+  cpp = list(density = "exponential_mean", sample = "exponential_mean"))
 
 distr_gamma_rate <- distribution(
   name = "Gamma",

--- a/R/rng.R
+++ b/R/rng.R
@@ -108,7 +108,10 @@
 ##' rng$poisson(5, 2)
 ##'
 ##' # Exponentially distributed random numbers with rate
-##' rng$exponential(5, 2)
+##' rng$exponential_rate(5, 2)
+##'
+##' # Exponentially distributed random numbers with mean
+##' rng$exponential_mean(5, 0.5)
 ##'
 ##' # Multinomial distributed random numbers with size and vector of
 ##' # probabiltiies prob
@@ -333,8 +336,21 @@ mcstate_rng <- R6::R6Class(
     ##' @param rate The rate of the exponential
     ##'
     ##' @param n_threads Number of threads to use; see Details
-    exponential = function(n, rate, n_threads = 1L) {
-      mcstate_rng_exponential(private$ptr, n, rate, n_threads, private$float)
+    exponential_rate = function(n, rate, n_threads = 1L) {
+      mcstate_rng_exponential_rate(private$ptr, n, rate, n_threads,
+                                   private$float)
+    },
+
+    ##' @description Generate `n` numbers from a exponential distribution
+    ##'
+    ##' @param n Number of samples to draw (per stream)
+    ##'
+    ##' @param mean The mean of the exponential
+    ##'
+    ##' @param n_threads Number of threads to use; see Details
+    exponential_mean = function(n, mean, n_threads = 1L) {
+      mcstate_rng_exponential_mean(private$ptr, n, mean, n_threads,
+                                   private$float)
     },
 
     ##' @description Generate `n` draws from a Cauchy distribution.

--- a/R/rng.R
+++ b/R/rng.R
@@ -101,8 +101,11 @@
 ##' # Hypergeometric distributed random numbers with parameters n1, n2 and k
 ##' rng$hypergeometric(5, 6, 10, 4)
 ##'
-##' # Gamma distributed random numbers with parameters a and b
-##' rng$gamma(5, 0.5, 2)
+##' # Gamma distributed random numbers with parameters shape and scale
+##' rng$gamma_scale(5, 0.5, 2)
+##'
+##' # Gamma distributed random numbers with parameters shape and rate
+##' rng$gamma_rate(5, 0.5, 2)
 ##'
 ##' # Poisson distributed random numbers with mean lambda
 ##' rng$poisson(5, 2)
@@ -312,9 +315,23 @@ mcstate_rng <- R6::R6Class(
     ##' @param scale Scale
     ##''
     ##' @param n_threads Number of threads to use; see Details
-    gamma = function(n, shape, scale, n_threads = 1L) {
-      mcstate_rng_gamma(private$ptr, n, shape, scale, n_threads,
-                        private$float)
+    gamma_scale = function(n, shape, scale, n_threads = 1L) {
+      mcstate_rng_gamma_scale(private$ptr, n, shape, scale, n_threads,
+                              private$float)
+    },
+
+    ##' @description Generate `n` numbers from a gamma distribution
+    ##'
+    ##' @param n Number of samples to draw (per stream)
+    ##'
+    ##' @param shape Shape
+    ##'
+    ##' @param rate Rate
+    ##''
+    ##' @param n_threads Number of threads to use; see Details
+    gamma_rate = function(n, shape, rate, n_threads = 1L) {
+      mcstate_rng_gamma_rate(private$ptr, n, shape, rate, n_threads,
+                             private$float)
     },
 
     ##' @description Generate `n` numbers from a Poisson distribution

--- a/R/rng.R
+++ b/R/rng.R
@@ -405,6 +405,19 @@ mcstate_rng <- R6::R6Class(
                               private$float)
     },
 
+    ##' @description Generate `n` numbers from a beta distribution
+    ##'
+    ##' @param n Number of samples to draw (per stream)
+    ##'
+    ##' @param a The first shape parameter
+    ##'
+    ##' @param b The second shape parameter
+    ##'
+    ##' @param n_threads Number of threads to use; see Details
+    beta = function(n, a, b, n_threads = 1L) {
+      mcstate_rng_beta(private$ptr, n, a, b, n_threads, private$float)
+    },
+
     ##' @description
     ##' Returns the state of the random number stream. This returns a
     ##' raw vector of length 32 * n_streams. It is primarily intended for

--- a/inst/include/mcstate/random/beta.hpp
+++ b/inst/include/mcstate/random/beta.hpp
@@ -22,8 +22,8 @@ real_type beta(rng_state_type& rng_state, real_type a, real_type b) {
     return a / (a + b);
   }
 
-  const auto x = gamma_scale<real_type>(a, 1);
-  const auto y = gamma_scale<real_type>(b, 1);
+  const auto x = gamma_scale<real_type>(rng_state, a, 1);
+  const auto y = gamma_scale<real_type>(rng_state, b, 1);
   return x / (x + y);
 }
 

--- a/inst/include/mcstate/random/beta.hpp
+++ b/inst/include/mcstate/random/beta.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include "mcstate/random/gamma.hpp"
+
+namespace mcstate {
+namespace random {
+
+template <typename real_type, typename rng_state_type>
+__host__ __device__
+real_type beta(rng_state_type& rng_state, real_type a, real_type b) {
+  static_assert(std::is_floating_point<real_type>::value,
+                "Only valid for floating-point types; use beta<real_type>()");
+#ifdef __CUDA_ARCH__
+  static_assert("gamma() not implemented for GPU targets");
+#endif
+
+  if (rng_state.deterministic) {
+    return a / (a + b);
+  }
+
+  const auto x = gamma_scale<real_type>(a, 1);
+  const auto y = gamma_scale<real_type>(b, 1);
+  return x / (x + y);
+}
+
+}
+}

--- a/inst/include/mcstate/random/density.hpp
+++ b/inst/include/mcstate/random/density.hpp
@@ -179,5 +179,26 @@ __host__ __device__ T poisson(int x, T lambda, bool log) {
   return maybe_log(ret, log);
 }
 
+template <typename T>
+__host__ __device__ T exponential_rate(T x, T rate, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "exponential should only be used with real types");
+#endif
+  return maybe_log(mcstate::math::log(rate) - rate * x, log);
+}
+
+template <typename T>
+__host__ __device__ T exponential_mean(T x, T mean, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "exponential should only be used with real types");
+#endif
+  return maybe_log(-mcstate::math::log(mean) - x / mean, log);
+}
+
+
+
+
 }
 }

--- a/inst/include/mcstate/random/density.hpp
+++ b/inst/include/mcstate/random/density.hpp
@@ -221,5 +221,26 @@ __host__ __device__ T gamma_scale(T x, T shape, T scale, bool log) {
 }
 
 
+template <typename T>
+__host__ __device__ T uniform(T x, T min, T max, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "uniform should only be used with real types");
+#endif
+  const auto ret = (x < min || x > max) ? 0 : 1 / (max - min);
+  return log ? mcstate::math::log(ret) : ret;
+}
+
+template <typename T>
+__host__ __device__ T hypergeometric(T x, T n1, T n2, T k, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "hypergeometric should only be used with real types");
+#endif
+  const auto ret = lchoose<T>(n1, x) + lchoose<T>(n2, k - x) -
+    lchoose<T>(n1 + n2, k);
+  return maybe_log(ret, log);
+}
+
 }
 }

--- a/inst/include/mcstate/random/density.hpp
+++ b/inst/include/mcstate/random/density.hpp
@@ -188,6 +188,7 @@ __host__ __device__ T exponential_rate(T x, T rate, bool log) {
   return maybe_log(mcstate::math::log(rate) - rate * x, log);
 }
 
+// TODO: rename as scale
 template <typename T>
 __host__ __device__ T exponential_mean(T x, T mean, bool log) {
 #ifndef __CUDA_ARCH__
@@ -197,7 +198,27 @@ __host__ __device__ T exponential_mean(T x, T mean, bool log) {
   return maybe_log(-mcstate::math::log(mean) - x / mean, log);
 }
 
+template <typename T>
+__host__ __device__ T gamma_rate(T x, T shape, T rate, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "gamma should only be used with real types");
+#endif
+  const auto ret = (shape - 1) * mcstate::math::log(x) - rate * x -
+    random::utils::lgamma(shape) + shape * mcstate::math::log(rate);
+  return maybe_log(ret, log);
+}
 
+template <typename T>
+__host__ __device__ T gamma_scale(T x, T shape, T scale, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "gamma should only be used with real types");
+#endif
+  const auto ret = (shape - 1) * mcstate::math::log(x) - x / scale -
+    random::utils::lgamma(shape) - shape * mcstate::math::log(scale);
+  return maybe_log(ret, log);
+}
 
 
 }

--- a/inst/include/mcstate/random/density.hpp
+++ b/inst/include/mcstate/random/density.hpp
@@ -242,5 +242,16 @@ __host__ __device__ T hypergeometric(T x, T n1, T n2, T k, bool log) {
   return maybe_log(ret, log);
 }
 
+template <typename T>
+__host__ __device__ T beta(T x, T a, T b, bool log) {
+#ifndef __CUDA_ARCH__
+  static_assert(std::is_floating_point<T>::value,
+                "beta should only be used with real types");
+#endif
+  const auto ret = (a - 1) * mcstate::math::log(x) +
+    (b - 1) * mcstate::math::log(1 - x) - lbeta(a, b);
+  return maybe_log(ret, log);
+}
+
 }
 }

--- a/inst/include/mcstate/random/exponential.hpp
+++ b/inst/include/mcstate/random/exponential.hpp
@@ -46,10 +46,19 @@ real_type exponential_rand(rng_state_type& rng_state) {
 __nv_exec_check_disable__
 template <typename real_type, typename rng_state_type>
 __host__ __device__
-real_type exponential(rng_state_type& rng_state, real_type rate) {
+real_type exponential_rate(rng_state_type& rng_state, real_type rate) {
   static_assert(std::is_floating_point<real_type>::value,
                 "Only valid for floating-point types; use exponential<real_type>()");
   return exponential_rand<real_type>(rng_state) / rate;
+}
+
+__nv_exec_check_disable__
+template <typename real_type, typename rng_state_type>
+__host__ __device__
+real_type exponential_mean(rng_state_type& rng_state, real_type mean) {
+  static_assert(std::is_floating_point<real_type>::value,
+                "Only valid for floating-point types; use exponential<real_type>()");
+  return exponential_rand<real_type>(rng_state) * mean;
 }
 
 }

--- a/inst/include/mcstate/random/gamma.hpp
+++ b/inst/include/mcstate/random/gamma.hpp
@@ -104,7 +104,7 @@ real_type gamma(rng_state_type& rng_state, real_type shape, real_type scale) {
   }
 
   if (shape == 1) {
-    return exponential(rng_state, 1 / scale);
+    return exponential_mean(rng_state, scale);
   }
 
   return gamma_large<real_type>(rng_state, shape) * scale;

--- a/inst/include/mcstate/random/gamma.hpp
+++ b/inst/include/mcstate/random/gamma.hpp
@@ -81,7 +81,7 @@ real_type gamma_deterministic(real_type shape, real_type scale) {
 /// @param b Scale
 template <typename real_type, typename rng_state_type>
 __host__ __device__
-real_type gamma(rng_state_type& rng_state, real_type shape, real_type scale) {
+real_type gamma_scale(rng_state_type& rng_state, real_type shape, real_type scale) {
   static_assert(std::is_floating_point<real_type>::value,
                 "Only valid for floating-point types; use gamma<real_type>()");
 
@@ -108,6 +108,16 @@ real_type gamma(rng_state_type& rng_state, real_type shape, real_type scale) {
   }
 
   return gamma_large<real_type>(rng_state, shape) * scale;
+}
+
+template <typename real_type, typename rng_state_type>
+__host__ __device__
+real_type gamma_rate(rng_state_type& rng_state, real_type shape, real_type rate) {
+  static_assert(std::is_floating_point<real_type>::value,
+                "Only valid for floating-point types; use gamma<real_type>()");
+  const auto scale = 1 / rate;
+  gamma_validate(shape, scale);
+  return gamma_scale<real_type>(rng_state, shape, scale);
 }
 
 }

--- a/inst/include/mcstate/random/nbinomial.hpp
+++ b/inst/include/mcstate/random/nbinomial.hpp
@@ -34,7 +34,7 @@ real_type nbinomial(rng_state_type& rng_state, real_type size, real_type prob) {
     if (rng_state.deterministic) {
       return (1 - prob) * size / prob;
     }
-    return (prob == 1) ? 0 : poisson(rng_state, gamma(rng_state, size, (1 - prob) / prob));
+    return (prob == 1) ? 0 : poisson(rng_state, gamma_scale(rng_state, size, (1 - prob) / prob));
 }
 
 }

--- a/inst/include/mcstate/random/random.hpp
+++ b/inst/include/mcstate/random/random.hpp
@@ -3,6 +3,7 @@
 #include "mcstate/random/generator.hpp"
 #include "mcstate/random/prng.hpp"
 
+#include "mcstate/random/beta.hpp"
 #include "mcstate/random/binomial.hpp"
 #include "mcstate/random/cauchy.hpp"
 #include "mcstate/random/exponential.hpp"

--- a/man/mcstate_rng.Rd
+++ b/man/mcstate_rng.Rd
@@ -102,14 +102,20 @@ rng$nbinomial(5, 10, 0.3)
 # Hypergeometric distributed random numbers with parameters n1, n2 and k
 rng$hypergeometric(5, 6, 10, 4)
 
-# Gamma distributed random numbers with parameters a and b
-rng$gamma(5, 0.5, 2)
+# Gamma distributed random numbers with parameters shape and scale
+rng$gamma_scale(5, 0.5, 2)
+
+# Gamma distributed random numbers with parameters shape and rate
+rng$gamma_rate(5, 0.5, 2)
 
 # Poisson distributed random numbers with mean lambda
 rng$poisson(5, 2)
 
 # Exponentially distributed random numbers with rate
-rng$exponential(5, 2)
+rng$exponential_rate(5, 2)
+
+# Exponentially distributed random numbers with mean
+rng$exponential_mean(5, 0.5)
 
 # Multinomial distributed random numbers with size and vector of
 # probabiltiies prob
@@ -136,9 +142,11 @@ rng$multinomial(5, 10, c(0.1, 0.3, 0.5, 0.1))
 \item \href{#method-mcstate_rng-binomial}{\code{mcstate_rng$binomial()}}
 \item \href{#method-mcstate_rng-nbinomial}{\code{mcstate_rng$nbinomial()}}
 \item \href{#method-mcstate_rng-hypergeometric}{\code{mcstate_rng$hypergeometric()}}
-\item \href{#method-mcstate_rng-gamma}{\code{mcstate_rng$gamma()}}
+\item \href{#method-mcstate_rng-gamma_scale}{\code{mcstate_rng$gamma_scale()}}
+\item \href{#method-mcstate_rng-gamma_rate}{\code{mcstate_rng$gamma_rate()}}
 \item \href{#method-mcstate_rng-poisson}{\code{mcstate_rng$poisson()}}
-\item \href{#method-mcstate_rng-exponential}{\code{mcstate_rng$exponential()}}
+\item \href{#method-mcstate_rng-exponential_rate}{\code{mcstate_rng$exponential_rate()}}
+\item \href{#method-mcstate_rng-exponential_mean}{\code{mcstate_rng$exponential_mean()}}
 \item \href{#method-mcstate_rng-cauchy}{\code{mcstate_rng$cauchy()}}
 \item \href{#method-mcstate_rng-multinomial}{\code{mcstate_rng$multinomial()}}
 \item \href{#method-mcstate_rng-state}{\code{mcstate_rng$state()}}
@@ -384,12 +392,12 @@ R's \link{rhyper})}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-mcstate_rng-gamma"></a>}}
-\if{latex}{\out{\hypertarget{method-mcstate_rng-gamma}{}}}
-\subsection{Method \code{gamma()}}{
+\if{html}{\out{<a id="method-mcstate_rng-gamma_scale"></a>}}
+\if{latex}{\out{\hypertarget{method-mcstate_rng-gamma_scale}{}}}
+\subsection{Method \code{gamma_scale()}}{
 Generate \code{n} numbers from a gamma distribution
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$gamma(n, shape, scale, n_threads = 1L)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$gamma_scale(n, shape, scale, n_threads = 1L)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -400,6 +408,30 @@ Generate \code{n} numbers from a gamma distribution
 \item{\code{shape}}{Shape}
 
 \item{\code{scale}}{Scale
+'}
+
+\item{\code{n_threads}}{Number of threads to use; see Details}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-mcstate_rng-gamma_rate"></a>}}
+\if{latex}{\out{\hypertarget{method-mcstate_rng-gamma_rate}{}}}
+\subsection{Method \code{gamma_rate()}}{
+Generate \code{n} numbers from a gamma distribution
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$gamma_rate(n, shape, rate, n_threads = 1L)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{Number of samples to draw (per stream)}
+
+\item{\code{shape}}{Shape}
+
+\item{\code{rate}}{Rate
 '}
 
 \item{\code{n_threads}}{Number of threads to use; see Details}
@@ -430,12 +462,12 @@ lambda <= 10^7}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-mcstate_rng-exponential"></a>}}
-\if{latex}{\out{\hypertarget{method-mcstate_rng-exponential}{}}}
-\subsection{Method \code{exponential()}}{
+\if{html}{\out{<a id="method-mcstate_rng-exponential_rate"></a>}}
+\if{latex}{\out{\hypertarget{method-mcstate_rng-exponential_rate}{}}}
+\subsection{Method \code{exponential_rate()}}{
 Generate \code{n} numbers from a exponential distribution
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$exponential(n, rate, n_threads = 1L)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$exponential_rate(n, rate, n_threads = 1L)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -444,6 +476,27 @@ Generate \code{n} numbers from a exponential distribution
 \item{\code{n}}{Number of samples to draw (per stream)}
 
 \item{\code{rate}}{The rate of the exponential}
+
+\item{\code{n_threads}}{Number of threads to use; see Details}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-mcstate_rng-exponential_mean"></a>}}
+\if{latex}{\out{\hypertarget{method-mcstate_rng-exponential_mean}{}}}
+\subsection{Method \code{exponential_mean()}}{
+Generate \code{n} numbers from a exponential distribution
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{mcstate_rng$exponential_mean(n, mean, n_threads = 1L)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{Number of samples to draw (per stream)}
+
+\item{\code{mean}}{The mean of the exponential}
 
 \item{\code{n_threads}}{Number of threads to use; see Details}
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -92,10 +92,17 @@ extern "C" SEXP _mcstate2_mcstate_rng_hypergeometric(SEXP ptr, SEXP n, SEXP r_n1
   END_CPP11
 }
 // random.cpp
-cpp11::sexp mcstate_rng_gamma(SEXP ptr, int n, cpp11::doubles r_a, cpp11::doubles r_b, int n_threads, bool is_float);
-extern "C" SEXP _mcstate2_mcstate_rng_gamma(SEXP ptr, SEXP n, SEXP r_a, SEXP r_b, SEXP n_threads, SEXP is_float) {
+cpp11::sexp mcstate_rng_gamma_scale(SEXP ptr, int n, cpp11::doubles r_shape, cpp11::doubles r_scale, int n_threads, bool is_float);
+extern "C" SEXP _mcstate2_mcstate_rng_gamma_scale(SEXP ptr, SEXP n, SEXP r_shape, SEXP r_scale, SEXP n_threads, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(mcstate_rng_gamma(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_a), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_b), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+    return cpp11::as_sexp(mcstate_rng_gamma_scale(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_shape), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_scale), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+  END_CPP11
+}
+// random.cpp
+cpp11::sexp mcstate_rng_gamma_rate(SEXP ptr, int n, cpp11::doubles r_shape, cpp11::doubles r_rate, int n_threads, bool is_float);
+extern "C" SEXP _mcstate2_mcstate_rng_gamma_rate(SEXP ptr, SEXP n, SEXP r_shape, SEXP r_rate, SEXP n_threads, SEXP is_float) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(mcstate_rng_gamma_rate(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_shape), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // random.cpp
@@ -163,7 +170,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_mcstate2_mcstate_rng_cauchy",           (DL_FUNC) &_mcstate2_mcstate_rng_cauchy,           6},
     {"_mcstate2_mcstate_rng_exponential_mean", (DL_FUNC) &_mcstate2_mcstate_rng_exponential_mean, 5},
     {"_mcstate2_mcstate_rng_exponential_rate", (DL_FUNC) &_mcstate2_mcstate_rng_exponential_rate, 5},
-    {"_mcstate2_mcstate_rng_gamma",            (DL_FUNC) &_mcstate2_mcstate_rng_gamma,            6},
+    {"_mcstate2_mcstate_rng_gamma_rate",       (DL_FUNC) &_mcstate2_mcstate_rng_gamma_rate,       6},
+    {"_mcstate2_mcstate_rng_gamma_scale",      (DL_FUNC) &_mcstate2_mcstate_rng_gamma_scale,      6},
     {"_mcstate2_mcstate_rng_hypergeometric",   (DL_FUNC) &_mcstate2_mcstate_rng_hypergeometric,   7},
     {"_mcstate2_mcstate_rng_jump",             (DL_FUNC) &_mcstate2_mcstate_rng_jump,             2},
     {"_mcstate2_mcstate_rng_long_jump",        (DL_FUNC) &_mcstate2_mcstate_rng_long_jump,        2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -120,6 +120,13 @@ extern "C" SEXP _mcstate2_mcstate_rng_cauchy(SEXP ptr, SEXP n, SEXP r_location, 
   END_CPP11
 }
 // random.cpp
+cpp11::sexp mcstate_rng_beta(SEXP ptr, int n, cpp11::doubles r_a, cpp11::doubles r_b, int n_threads, bool is_float);
+extern "C" SEXP _mcstate2_mcstate_rng_beta(SEXP ptr, SEXP n, SEXP r_a, SEXP r_b, SEXP n_threads, SEXP is_float) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(mcstate_rng_beta(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_a), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_b), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+  END_CPP11
+}
+// random.cpp
 cpp11::sexp mcstate_rng_multinomial(SEXP ptr, int n, cpp11::doubles r_size, cpp11::doubles r_prob, int n_threads, bool is_float);
 extern "C" SEXP _mcstate2_mcstate_rng_multinomial(SEXP ptr, SEXP n, SEXP r_size, SEXP r_prob, SEXP n_threads, SEXP is_float) {
   BEGIN_CPP11
@@ -166,6 +173,7 @@ extern "C" SEXP _mcstate2_test_xoshiro_run(SEXP obj) {
 extern "C" {
 static const R_CallMethodDef CallEntries[] = {
     {"_mcstate2_mcstate_rng_alloc",            (DL_FUNC) &_mcstate2_mcstate_rng_alloc,            4},
+    {"_mcstate2_mcstate_rng_beta",             (DL_FUNC) &_mcstate2_mcstate_rng_beta,             6},
     {"_mcstate2_mcstate_rng_binomial",         (DL_FUNC) &_mcstate2_mcstate_rng_binomial,         6},
     {"_mcstate2_mcstate_rng_cauchy",           (DL_FUNC) &_mcstate2_mcstate_rng_cauchy,           6},
     {"_mcstate2_mcstate_rng_exponential_mean", (DL_FUNC) &_mcstate2_mcstate_rng_exponential_mean, 5},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -50,10 +50,17 @@ extern "C" SEXP _mcstate2_mcstate_rng_uniform(SEXP ptr, SEXP n, SEXP r_min, SEXP
   END_CPP11
 }
 // random.cpp
-cpp11::sexp mcstate_rng_exponential(SEXP ptr, int n, cpp11::doubles r_rate, int n_threads, bool is_float);
-extern "C" SEXP _mcstate2_mcstate_rng_exponential(SEXP ptr, SEXP n, SEXP r_rate, SEXP n_threads, SEXP is_float) {
+cpp11::sexp mcstate_rng_exponential_rate(SEXP ptr, int n, cpp11::doubles r_rate, int n_threads, bool is_float);
+extern "C" SEXP _mcstate2_mcstate_rng_exponential_rate(SEXP ptr, SEXP n, SEXP r_rate, SEXP n_threads, SEXP is_float) {
   BEGIN_CPP11
-    return cpp11::as_sexp(mcstate_rng_exponential(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+    return cpp11::as_sexp(mcstate_rng_exponential_rate(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_rate), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
+  END_CPP11
+}
+// random.cpp
+cpp11::sexp mcstate_rng_exponential_mean(SEXP ptr, int n, cpp11::doubles r_mean, int n_threads, bool is_float);
+extern "C" SEXP _mcstate2_mcstate_rng_exponential_mean(SEXP ptr, SEXP n, SEXP r_mean, SEXP n_threads, SEXP is_float) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(mcstate_rng_exponential_mean(cpp11::as_cpp<cpp11::decay_t<SEXP>>(ptr), cpp11::as_cpp<cpp11::decay_t<int>>(n), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_mean), cpp11::as_cpp<cpp11::decay_t<int>>(n_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(is_float)));
   END_CPP11
 }
 // random.cpp
@@ -151,26 +158,27 @@ extern "C" SEXP _mcstate2_test_xoshiro_run(SEXP obj) {
 
 extern "C" {
 static const R_CallMethodDef CallEntries[] = {
-    {"_mcstate2_mcstate_rng_alloc",          (DL_FUNC) &_mcstate2_mcstate_rng_alloc,          4},
-    {"_mcstate2_mcstate_rng_binomial",       (DL_FUNC) &_mcstate2_mcstate_rng_binomial,       6},
-    {"_mcstate2_mcstate_rng_cauchy",         (DL_FUNC) &_mcstate2_mcstate_rng_cauchy,         6},
-    {"_mcstate2_mcstate_rng_exponential",    (DL_FUNC) &_mcstate2_mcstate_rng_exponential,    5},
-    {"_mcstate2_mcstate_rng_gamma",          (DL_FUNC) &_mcstate2_mcstate_rng_gamma,          6},
-    {"_mcstate2_mcstate_rng_hypergeometric", (DL_FUNC) &_mcstate2_mcstate_rng_hypergeometric, 7},
-    {"_mcstate2_mcstate_rng_jump",           (DL_FUNC) &_mcstate2_mcstate_rng_jump,           2},
-    {"_mcstate2_mcstate_rng_long_jump",      (DL_FUNC) &_mcstate2_mcstate_rng_long_jump,      2},
-    {"_mcstate2_mcstate_rng_multinomial",    (DL_FUNC) &_mcstate2_mcstate_rng_multinomial,    6},
-    {"_mcstate2_mcstate_rng_nbinomial",      (DL_FUNC) &_mcstate2_mcstate_rng_nbinomial,      6},
-    {"_mcstate2_mcstate_rng_normal",         (DL_FUNC) &_mcstate2_mcstate_rng_normal,         7},
-    {"_mcstate2_mcstate_rng_pointer_init",   (DL_FUNC) &_mcstate2_mcstate_rng_pointer_init,   4},
-    {"_mcstate2_mcstate_rng_pointer_sync",   (DL_FUNC) &_mcstate2_mcstate_rng_pointer_sync,   2},
-    {"_mcstate2_mcstate_rng_poisson",        (DL_FUNC) &_mcstate2_mcstate_rng_poisson,        5},
-    {"_mcstate2_mcstate_rng_random_normal",  (DL_FUNC) &_mcstate2_mcstate_rng_random_normal,  5},
-    {"_mcstate2_mcstate_rng_random_real",    (DL_FUNC) &_mcstate2_mcstate_rng_random_real,    4},
-    {"_mcstate2_mcstate_rng_state",          (DL_FUNC) &_mcstate2_mcstate_rng_state,          2},
-    {"_mcstate2_mcstate_rng_uniform",        (DL_FUNC) &_mcstate2_mcstate_rng_uniform,        6},
-    {"_mcstate2_test_rng_pointer_get",       (DL_FUNC) &_mcstate2_test_rng_pointer_get,       2},
-    {"_mcstate2_test_xoshiro_run",           (DL_FUNC) &_mcstate2_test_xoshiro_run,           1},
+    {"_mcstate2_mcstate_rng_alloc",            (DL_FUNC) &_mcstate2_mcstate_rng_alloc,            4},
+    {"_mcstate2_mcstate_rng_binomial",         (DL_FUNC) &_mcstate2_mcstate_rng_binomial,         6},
+    {"_mcstate2_mcstate_rng_cauchy",           (DL_FUNC) &_mcstate2_mcstate_rng_cauchy,           6},
+    {"_mcstate2_mcstate_rng_exponential_mean", (DL_FUNC) &_mcstate2_mcstate_rng_exponential_mean, 5},
+    {"_mcstate2_mcstate_rng_exponential_rate", (DL_FUNC) &_mcstate2_mcstate_rng_exponential_rate, 5},
+    {"_mcstate2_mcstate_rng_gamma",            (DL_FUNC) &_mcstate2_mcstate_rng_gamma,            6},
+    {"_mcstate2_mcstate_rng_hypergeometric",   (DL_FUNC) &_mcstate2_mcstate_rng_hypergeometric,   7},
+    {"_mcstate2_mcstate_rng_jump",             (DL_FUNC) &_mcstate2_mcstate_rng_jump,             2},
+    {"_mcstate2_mcstate_rng_long_jump",        (DL_FUNC) &_mcstate2_mcstate_rng_long_jump,        2},
+    {"_mcstate2_mcstate_rng_multinomial",      (DL_FUNC) &_mcstate2_mcstate_rng_multinomial,      6},
+    {"_mcstate2_mcstate_rng_nbinomial",        (DL_FUNC) &_mcstate2_mcstate_rng_nbinomial,        6},
+    {"_mcstate2_mcstate_rng_normal",           (DL_FUNC) &_mcstate2_mcstate_rng_normal,           7},
+    {"_mcstate2_mcstate_rng_pointer_init",     (DL_FUNC) &_mcstate2_mcstate_rng_pointer_init,     4},
+    {"_mcstate2_mcstate_rng_pointer_sync",     (DL_FUNC) &_mcstate2_mcstate_rng_pointer_sync,     2},
+    {"_mcstate2_mcstate_rng_poisson",          (DL_FUNC) &_mcstate2_mcstate_rng_poisson,          5},
+    {"_mcstate2_mcstate_rng_random_normal",    (DL_FUNC) &_mcstate2_mcstate_rng_random_normal,    5},
+    {"_mcstate2_mcstate_rng_random_real",      (DL_FUNC) &_mcstate2_mcstate_rng_random_real,      4},
+    {"_mcstate2_mcstate_rng_state",            (DL_FUNC) &_mcstate2_mcstate_rng_state,            2},
+    {"_mcstate2_mcstate_rng_uniform",          (DL_FUNC) &_mcstate2_mcstate_rng_uniform,          6},
+    {"_mcstate2_test_rng_pointer_get",         (DL_FUNC) &_mcstate2_test_rng_pointer_get,         2},
+    {"_mcstate2_test_xoshiro_run",             (DL_FUNC) &_mcstate2_test_xoshiro_run,             1},
     {NULL, NULL, 0}
 };
 }

--- a/tests/testthat/helper-mcstate2.R
+++ b/tests/testthat/helper-mcstate2.R
@@ -8,7 +8,7 @@ ex_simple_gamma1 <- function(shape = 1, rate = 1) {
       list(
         parameters = "gamma",
         direct_sample = function(rng) {
-          rng$gamma(1, shape = shape, scale = 1 / rate)
+          rng$gamma_scale(1, shape = shape, scale = 1 / rate)
         },
         density = function(x) {
           drop(dgamma(x, shape = shape, rate = rate, log = TRUE))
@@ -134,8 +134,8 @@ ex_dust_sir <- function(n_particles = 100, n_threads = 1,
   }
 
   direct_sample <- function(rng) {
-    c(rng$gamma(1, prior_beta_shape, 1 / prior_beta_rate),
-      rng$gamma(1, prior_gamma_shape, 1 / prior_gamma_rate))
+    c(rng$gamma_scale(1, prior_beta_shape, 1 / prior_beta_rate),
+      rng$gamma_scale(1, prior_gamma_shape, 1 / prior_gamma_rate))
   }
 
   set_rng_state <- function(rng_state) {

--- a/tests/testthat/test-dsl-distributions.R
+++ b/tests/testthat/test-dsl-distributions.R
@@ -59,9 +59,9 @@ test_that("can sample from exponential distribution", {
   r1 <- mcstate_rng$new(1)
   r2 <- mcstate_rng$new(1)
   expect_equal(distr_exponential_rate$sample(r1, 0.4),
-               r2$exponential(1, 0.4))
+               r2$exponential_rate(1, 0.4))
   expect_equal(distr_exponential_mean$sample(r1, 0.4),
-               r2$exponential(1, 1 / 0.4))
+               r2$exponential_mean(1, 0.4))
 })
 
 

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -1464,3 +1464,17 @@ test_that("beta generation algorithm is correct", {
   y <- rng2$gamma_scale(1, b, 1)
   expect_equal(r, x / (x + y))
 })
+
+
+test_that("deterministic beta returns mean", {
+  n <- 10
+  a <- rexp(n)
+  b <- rexp(n)
+
+  rng <- mcstate_rng$new(1, deterministic = TRUE)
+  state <- rng$state()
+
+  expect_equal(rng$beta(n, a, b), a / (a + b))
+
+  expect_equal(rng$state(), state)
+})

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -323,7 +323,7 @@ test_that("Prevent unknown normal algorithms", {
 test_that("rexp agrees with stats::rexp", {
   n <- 100000
   rate <- 0.04
-  ans <- mcstate_rng$new(2)$exponential(n, rate)
+  ans <- mcstate_rng$new(2)$exponential_rate(n, rate)
   expect_equal(mean(ans), 1 / rate, tolerance = 1e-2)
   expect_equal(var(ans), 1 / rate^2, tolerance = 1e-2)
   expect_gt(ks.test(ans, "pexp", rate)$p.value, 0.1)
@@ -658,7 +658,7 @@ test_that("std uniform random numbers from floats have correct distribution", {
 test_that("exponential random numbers from floats have correct distribution", {
   n <- 100000
   rate <- 4
-  yf <- mcstate_rng$new(1, real_type = "float")$exponential(n, rate)
+  yf <- mcstate_rng$new(1, real_type = "float")$exponential_rate(n, rate)
   expect_equal(mean(yf), 1 / rate, tolerance = 1e-2)
   expect_equal(var(yf), 1 / rate^2, tolerance = 5e-2)
   expect_gt(suppressWarnings(ks.test(yf, "pexp", rate)$p.value), 0.1)
@@ -956,8 +956,8 @@ test_that("deterministic rexp returns mean", {
   rng_d <- mcstate_rng$new(1, real_type = "double", deterministic = TRUE)
   state_f <- rng_f$state()
   state_d <- rng_d$state()
-  expect_equal(rng_f$exponential(m, rate), 1 / rate, tolerance = 1e-6)
-  expect_equal(rng_d$exponential(m, rate), 1 / rate)
+  expect_equal(rng_f$exponential_rate(m, rate), 1 / rate, tolerance = 1e-6)
+  expect_equal(rng_d$exponential_rate(m, rate), 1 / rate)
   expect_equal(rng_f$state(), state_f)
   expect_equal(rng_d$state(), state_d)
 })
@@ -1265,7 +1265,7 @@ test_that("gamma for a = 1 is the same as exponential", {
   b <- 3
 
   gamma <- rng1$gamma(n, 1, b)
-  exp <- rng2$exponential(n, 1 / b)
+  exp <- rng2$exponential_rate(n, 1 / b)
 
   expect_equal(gamma, exp)
 })
@@ -1423,4 +1423,11 @@ test_that("can fetch rng state", {
   expect_false(is.null(get_r_rng_state()))
   rm(list = ".Random.seed", envir = .GlobalEnv)
   expect_true(is.null(get_r_rng_state()))
+})
+
+
+test_that("exponential by mean agrees with rate", {
+  ans1 <- mcstate_rng$new(1)$exponential_rate(100, 0.5)
+  ans2 <- mcstate_rng$new(1)$exponential_mean(100, 2)
+  expect_equal(ans1, ans2)
 })

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -1264,7 +1264,7 @@ test_that("gamma for a = 1 is the same as exponential", {
   n <- 10
   b <- 3
 
-  gamma <- rng1$gamma(n, 1, b)
+  gamma <- rng1$gamma_scale(n, 1, b)
   exp <- rng2$exponential_rate(n, 1 / b)
 
   expect_equal(gamma, exp)
@@ -1277,28 +1277,28 @@ test_that("can draw gamma random numbers", {
   b <- 3
   n <- 10000000
 
-  ans1 <- mcstate_rng$new(1)$gamma(n, a, b)
-  ans2 <- mcstate_rng$new(1)$gamma(n, a, b)
+  ans1 <- mcstate_rng$new(1)$gamma_scale(n, a, b)
+  ans2 <- mcstate_rng$new(1)$gamma_scale(n, a, b)
   expect_identical(ans1, ans2)
 
   expect_equal(mean(ans1), a * b, tolerance = 1e-3)
   expect_equal(var(ans1), a * b^2, tolerance = 1e-3)
 
-  ans_f <- mcstate_rng$new(1, real_type = "float")$gamma(n, a, b)
+  ans_f <- mcstate_rng$new(1, real_type = "float")$gamma_scale(n, a, b)
   expect_equal(mean(ans_f), a * b, tolerance = 1e-3)
   expect_equal(var(ans_f), a * b^2, tolerance = 1e-3)
 
   ## when a < 1
   a <- 0.5
 
-  ans3 <- mcstate_rng$new(1)$gamma(n, a, b)
-  ans4 <- mcstate_rng$new(1)$gamma(n, a, b)
+  ans3 <- mcstate_rng$new(1)$gamma_scale(n, a, b)
+  ans4 <- mcstate_rng$new(1)$gamma_scale(n, a, b)
   expect_identical(ans3, ans4)
 
   expect_equal(mean(ans3), a * b, tolerance = 1e-3)
   expect_equal(var(ans3), a * b^2, tolerance = 1e-3)
 
-  ans_f <- mcstate_rng$new(1, real_type = "float")$gamma(n, a, b)
+  ans_f <- mcstate_rng$new(1, real_type = "float")$gamma_scale(n, a, b)
   expect_equal(mean(ans_f), a * b, tolerance = 1e-3)
   expect_equal(var(ans_f), a * b^2, tolerance = 1e-3)
 })
@@ -1314,9 +1314,9 @@ test_that("deterministic gamma returns mean", {
   state_f <- rng_f$state()
   state_d <- rng_d$state()
 
-  expect_equal(rng_f$gamma(n_reps, a, b), a * b,
+  expect_equal(rng_f$gamma_scale(n_reps, a, b), a * b,
                tolerance = 1e-6)
-  expect_equal(rng_d$gamma(n_reps, a, b), a * b)
+  expect_equal(rng_d$gamma_scale(n_reps, a, b), a * b)
 
   expect_equal(rng_f$state(), state_f)
   expect_equal(rng_d$state(), state_d)
@@ -1325,14 +1325,14 @@ test_that("deterministic gamma returns mean", {
 
 test_that("gamma random numbers prevent bad inputs", {
   r <- mcstate_rng$new(1)
-  expect_equal(r$gamma(1, 0, 0), 0)
-  expect_equal(r$gamma(1, Inf, Inf), Inf)
+  expect_equal(r$gamma_scale(1, 0, 0), 0)
+  expect_equal(r$gamma_scale(1, Inf, Inf), Inf)
 
   expect_error(
-    r$gamma(1, -1.1, 5.1),
+    r$gamma_scale(1, -1.1, 5.1),
     "Invalid call to gamma with shape = -1.1, scale = 5.1")
   expect_error(
-    r$gamma(1, 5.1, -1.1),
+    r$gamma_scale(1, 5.1, -1.1),
     "Invalid call to gamma with shape = 5.1, scale = -1.1")
 })
 

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -1271,6 +1271,16 @@ test_that("gamma for a = 1 is the same as exponential", {
 })
 
 
+test_that("gamma_rate follows from gamma_scale", {
+  rng1 <- mcstate_rng$new(seed = 1L)
+  rng2 <- mcstate_rng$new(seed = 1L)
+  b <- 3
+  expect_identical(
+    rng1$gamma_rate(100, 5, 1 / b),
+    rng2$gamma_scale(100, 5, b))
+})
+
+
 test_that("can draw gamma random numbers", {
   ## when a > 1
   a <- 5
@@ -1430,4 +1440,27 @@ test_that("exponential by mean agrees with rate", {
   ans1 <- mcstate_rng$new(1)$exponential_rate(100, 0.5)
   ans2 <- mcstate_rng$new(1)$exponential_mean(100, 2)
   expect_equal(ans1, ans2)
+})
+
+
+test_that("can sample from the beta distribution", {
+  rng <- mcstate_rng$new(1, seed = 42)
+  a <- 2.5
+  b <- 1.5
+  r <- rng$beta(1000000, a, b)
+  expect_equal(mean(r), a / (a + b), tolerance = 1e-3)
+  expect_equal(var(r), a * b / ((a + b)^2 * (a + b + 1)), tolerance = 1e-2)
+})
+
+
+test_that("beta generation algorithm is correct", {
+  rng1 <- mcstate_rng$new(1, seed = 42)
+  rng2 <- mcstate_rng$new(1, seed = 42)
+  a <- 2.5
+  b <- 1.5
+  r <- rng1$beta(1, a, b)
+
+  x <- rng2$gamma_scale(1, a, 1)
+  y <- rng2$gamma_scale(1, b, 1)
+  expect_equal(r, x / (x + y))
 })


### PR DESCRIPTION
Merge after #51, contains those commits.

Note that this PR will break both dust2 and mcstate2 as they make calls to distributions referenced here, but the fix is easy.

There are more distributions to add - negative binomial and beta binomial are pretty high up - but this fills in some important gaps.

We're also getting to the point where I need to start on overhauling the rng interface generally - the `mcstate_rng` bit was never really meant to be used like this, unfortunately, and we simply don't expose the densities for testing at all.  But a job for a future PR I think