### PR TITLE
Import version check/update scripts from orderly2

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+
+name: Check Version
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+
+    name: Check Version
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check version format and availability
+        run: ./scripts/check_version

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -44,3 +44,4 @@ jobs:
           clean: false
           branch: gh-pages
           folder: docs
+          single-commit: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate2
 Title: Next Generation mcstate
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://mrc-ide.github.io/orderly2
+url: https://mrc-ide.github.io/mcstate2
 
 template:
   bootstrap: 5

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -eu
+
+ACTION="${1:-patch}"
+CURRENT_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')
+MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+echo "Current version: ${CURRENT_VERSION}"
+
+if [ $# -gt 1 ]; then
+  echo "Invalid args"
+  exit 1
+fi
+
+case $ACTION in
+    reset)
+        echo "Resetting version"
+        LAST_VERSION=$(git show origin/main:DESCRIPTION | grep '^Version' | sed 's/.*: *//')
+        MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
+        MINOR=$(echo $LAST_VERSION | cut -d. -f2)
+        PATCH=$(echo $LAST_VERSION | cut -d. -f3)
+    ;;
+    major)
+        echo "Updating major version"
+        MAJOR=$(($MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    minor)
+        echo "Updating minor version"
+        MINOR=$(($MINOR + 1))
+        PATCH=0
+        ;;
+    patch)
+        echo "Updating patch version"
+        PATCH=$(($PATCH + 1))
+        ;;
+    *)
+        if echo "$ACTION" | grep -Eq "[0-9]+[.][0-9]+[.][0-9]+"; then
+            echo "Updating version directly"
+            MAJOR=$(echo $VERSION | cut -d. -f1)
+            MINOR=$(echo $VERSION | cut -d. -f2)
+            PATCH=$(echo $VERSION | cut -d. -f3)
+        else
+            echo "[ERROR] Invalid format version number '$VERSION' must be in format 'x.y.z'"
+            exit 1
+        fi
+        ;;
+esac
+
+NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "Updating to version: ${NEXT_VERSION}"
+
+sed -i "s/^Version: .*$/Version: ${NEXT_VERSION}/" DESCRIPTION

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+# Usage:
+#   check_version [<version>]
+#
+# If version is not given as a positional argument, then we'll read it
+# from the DESCRIPTION file.
+#
+# We assume that a version already exists as a tag.
+VERSION=${1:-$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')}
+TAG="v${VERSION}"
+
+echo "Proposed version number '$VERSION'"
+
+if echo "$VERSION" | grep -Eq "[0-9]+[.][0-9]+[.][0-9]+"; then
+    echo "[OK] Version number in correct format"
+else
+    echo "[ERROR] Invalid format version number '$VERSION' must be in format 'x.y.z'"
+    exit 1
+fi
+
+EXIT_CODE=0
+
+LAST_VERSION=$(git show origin/main:DESCRIPTION | grep '^Version' | sed 's/.*: *//')
+
+echo "Last version was '$LAST_VERSION'"
+
+MAJOR=$(echo $VERSION | cut -d. -f1)
+MINOR=$(echo $VERSION | cut -d. -f2)
+PATCH=$(echo $VERSION | cut -d. -f3)
+
+LAST_VERSION=$(echo "$LAST_VERSION" | sed 's/^v//')
+LAST_MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
+LAST_MINOR=$(echo $LAST_VERSION | cut -d. -f2)
+LAST_PATCH=$(echo $LAST_VERSION | cut -d. -f3)
+
+if (( $MAJOR > $LAST_MAJOR )); then
+    echo "[OK] ${VERSION} increases MAJOR version over old version ${LAST_VERSION}"
+elif (( $MINOR > $LAST_MINOR )); then
+    echo "[OK] ${VERSION} increases MINOR version over old version ${LAST_VERSION}"
+elif (( $PATCH > $LAST_PATCH )); then
+    echo "[OK] ${VERSION} increases PATCH version over old version ${LAST_VERSION}"
+else
+    echo "[ERROR] Version number has not increased relative to $LAST_VERSION"
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
We're at the point now where this would be useful I think. See the failing check on the first commit before I updated the version number (with `./scripts/bump_version`).

I've also set up the pages build to ignore history and fix the pkgdown url