### PR TITLE
Allow scalars to be passed as rank-0 arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcstate2
 Title: Next Generation mcstate
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/packer.R
+++ b/R/packer.R
@@ -91,9 +91,12 @@
 ##' @param array A list, where names correspond to the names of array
 ##'   parameters and values correspond to the lengths of parameters.
 ##'   Multiple dimensions are allowed (so if you provide an element
-##'   with two entries these represent dimensions of a matrix).  In
-##'   future, you may be able to use *strings* as values for the
-##'   lengths, in which case these will be looked for within `fixed`.
+##'   with two entries these represent dimensions of a matrix).
+##'   Zero-length integer vectors or `NULL` values are counted as
+##'   scalars, which allows you to put scalars at positions other than
+##'   the front of the packing vector. In future, you may be able to
+##'   use *strings* as values for the lengths, in which case these
+##'   will be looked for within `fixed`.
 ##'
 ##' @param fixed A named list of fixed parameters; these will be added
 ##'   into the final list directly.  These typically represent
@@ -259,17 +262,17 @@ mcstate_packer <- function(scalar = NULL, array = NULL, fixed = NULL,
 ## Helper function to create array bookkeeping for the
 ## unpacking/packing process.
 prepare_pack_array <- function(name, shape, call = NULL) {
-  if (length(shape) == 0) {
-    cli::cli_abort(
-      paste("Elements of 'array' must have at least one element, but",
-            "'{name}' has none"),
-      arg = "array", call = call)
+  if (is.null(shape)) {
+    shape <- integer()
   }
   if (!rlang::is_integerish(shape)) {
     cli::cli_abort(
       paste("Elements of 'array' must be integer-like vectors, but",
             "'{name}' is not"),
       arg = "array", call = call)
+  }
+  if (length(shape) == 0) {
+    return(list(names = name, shape = 1, n = 1L))
   }
   if (any(shape <= 0)) {
     cli::cli_abort(

--- a/man/mcstate_packer.Rd
+++ b/man/mcstate_packer.Rd
@@ -16,9 +16,12 @@ generated names that include square brackets.}
 \item{array}{A list, where names correspond to the names of array
 parameters and values correspond to the lengths of parameters.
 Multiple dimensions are allowed (so if you provide an element
-with two entries these represent dimensions of a matrix).  In
-future, you may be able to use \emph{strings} as values for the
-lengths, in which case these will be looked for within \code{fixed}.}
+with two entries these represent dimensions of a matrix).
+Zero-length integer vectors or \code{NULL} values are counted as
+scalars, which allows you to put scalars at positions other than
+the front of the packing vector. In future, you may be able to
+use \emph{strings} as values for the lengths, in which case these
+will be looked for within \code{fixed}.}
 
 \item{fixed}{A named list of fixed parameters; these will be added
 into the final list directly.  These typically represent

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -102,14 +102,27 @@ test_that("names for scalar, array and fixed must be reasonable", {
 
 test_that("validate array inputs", {
   expect_error(
-    mcstate_packer(array = list(a = integer(), b = 2)),
-    "Elements of 'array' must have at least one element, but 'a' has none")
-  expect_error(
     mcstate_packer(array = list(a = 1, b = 2.5)),
     "Elements of 'array' must be integer-like vectors, but 'b' is not")
   expect_error(
     mcstate_packer(array = list(a = 1, b = c(3, 0, 2))),
     "All dimensions in 'array' must be at least 1, but 'b' violates this")
+})
+
+
+test_that("can pass empty array elements as scalars", {
+  p <- mcstate_packer(array = list(a = integer(), b = 2))
+  expect_equal(p$parameters, c("a", "b[1]", "b[2]"))
+  expect_equal(p$unpack(1:3), list(a = 1, b = 2:3))
+  expect_equal(p$pack(list(a = 1, b = 2:3)), 1:3)
+})
+
+
+test_that("can pass empty array elements as scalars in odd order", {
+  p <- mcstate_packer(array = list(a = 2, b = NULL))
+  expect_equal(p$parameters, c("a[1]", "a[2]", "b"))
+  expect_equal(p$unpack(1:3), list(a = 1:2, b = 3))
+  expect_equal(p$pack(list(a = 1:2, b = 3)), 1:3)
 })
 
 


### PR DESCRIPTION
This will be useful in dust's code; see https://github.com/mrc-ide/dust2/pull/53/files#r1719553938 for details